### PR TITLE
fix(cosmos): decode staking message bodies for raw-signing verification (SEC-342)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -340,6 +340,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@mysten/sui": "^1.39.0",
+        "@noble/hashes": "^2.2.0",
         "@protocols/shared": "workspace:*",
         "@protocols/ui": "workspace:*",
         "@uiw/react-json-view": "^2.0.0-alpha.36",
@@ -347,7 +348,6 @@
         "react-dom": "^19.1.2",
       },
       "devDependencies": {
-        "@noble/hashes": "^2.2.0",
         "@tailwindcss/vite": "^4.1.13",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -472,6 +472,8 @@
       "dependencies": {
         "@cosmjs/proto-signing": "^0.36.0",
         "@protocols/shared": "workspace:*",
+        "@protocols/ui": "workspace:*",
+        "cosmjs-types": "^0.10.0",
       },
       "devDependencies": {
         "@types/react": "^19.0.0",

--- a/packages/cosmos-shared/package.json
+++ b/packages/cosmos-shared/package.json
@@ -16,7 +16,9 @@
   },
   "dependencies": {
     "@cosmjs/proto-signing": "^0.36.0",
-    "@protocols/shared": "workspace:*"
+    "@protocols/shared": "workspace:*",
+    "@protocols/ui": "workspace:*",
+    "cosmjs-types": "^0.10.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/packages/cosmos-shared/src/CosmosTransactionSummary.tsx
+++ b/packages/cosmos-shared/src/CosmosTransactionSummary.tsx
@@ -1,0 +1,267 @@
+import { Address, Badge, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@protocols/ui';
+import { AlertTriangleIcon, ArrowLeftRightIcon, FuelIcon, UserIcon } from 'lucide-react';
+import type { CosmosCoin, CosmosMessage, CosmosTransaction } from './parser';
+
+type CosmosTransactionSummaryProps = {
+  transaction: CosmosTransaction;
+};
+
+// Message kinds that are the expected, benign output of a staking dashboard.
+const EXPECTED_KINDS: ReadonlySet<CosmosMessage['kind']> = new Set(['delegate', 'undelegate', 'withdrawRewards']);
+
+const isExpectedMessage = (message: CosmosMessage): boolean => EXPECTED_KINDS.has(message.kind);
+
+const getMessageLabel = (message: CosmosMessage): string => {
+  switch (message.kind) {
+    case 'delegate':
+      return 'Delegate';
+    case 'undelegate':
+      return 'Undelegate';
+    case 'redelegate':
+      return 'Redelegate';
+    case 'withdrawRewards':
+      return 'Withdraw Rewards';
+    case 'send':
+      return 'Send';
+    case 'authzGrant':
+      return 'Authz Grant';
+    case 'authzExec':
+      return 'Authz Exec';
+    case 'authzRevoke':
+      return 'Authz Revoke';
+    case 'unsupported':
+      return 'Unsupported';
+    default:
+      return 'Unknown';
+  }
+};
+
+const formatCoin = (coin: CosmosCoin | null): string => (coin ? `${coin.amount} ${coin.denom}` : '-');
+
+const formatCoins = (coins: CosmosCoin[]): string =>
+  coins.length > 0 ? coins.map((coin) => `${coin.amount} ${coin.denom}`).join(', ') : '-';
+
+const getMessageValidator = (message: CosmosMessage): string => {
+  switch (message.kind) {
+    case 'delegate':
+    case 'undelegate':
+    case 'withdrawRewards':
+      return message.validatorAddress;
+    case 'redelegate':
+      return `${message.validatorSrcAddress} → ${message.validatorDstAddress}`;
+    default:
+      return '-';
+  }
+};
+
+const getMessageAccount = (message: CosmosMessage): string => {
+  switch (message.kind) {
+    case 'delegate':
+    case 'undelegate':
+    case 'redelegate':
+    case 'withdrawRewards':
+      return message.delegatorAddress;
+    case 'send':
+      return message.fromAddress;
+    case 'authzGrant':
+    case 'authzRevoke':
+      return message.granter;
+    case 'authzExec':
+      return message.grantee;
+    default:
+      return '-';
+  }
+};
+
+const getMessageAmount = (message: CosmosMessage): string => {
+  switch (message.kind) {
+    case 'delegate':
+    case 'undelegate':
+    case 'redelegate':
+      return formatCoin(message.amount);
+    case 'send':
+      return formatCoins(message.amount);
+    default:
+      return '-';
+  }
+};
+
+const getMessageDetails = (message: CosmosMessage): string => {
+  switch (message.kind) {
+    case 'delegate':
+    case 'undelegate':
+      return `Validator: ${message.validatorAddress}`;
+    case 'redelegate':
+      return `${message.validatorSrcAddress} → ${message.validatorDstAddress}`;
+    case 'withdrawRewards':
+      return `Validator: ${message.validatorAddress}`;
+    case 'send':
+      return `To: ${message.toAddress}`;
+    case 'authzGrant':
+      return `Grantee: ${message.grantee} (${message.authorizationType})`;
+    case 'authzExec':
+      return `Nested: ${message.innerTypeUrls.join(', ') || 'none'}`;
+    case 'authzRevoke':
+      return `Grantee: ${message.grantee} (${message.msgTypeUrl})`;
+    case 'unsupported':
+      return message.typeUrl || 'unknown type';
+    default:
+      return '-';
+  }
+};
+
+export function CosmosTransactionSummary({ transaction }: CosmosTransactionSummaryProps) {
+  if (!transaction || transaction.messages.length === 0) return null;
+
+  const primaryMessage = transaction.messages[0];
+  const hasUnexpectedMessages = transaction.messages.some((message) => !isExpectedMessage(message));
+
+  return (
+    <div className="flex flex-col gap-7">
+      {hasUnexpectedMessages && (
+        <div className="bg-destructive/10 border border-destructive rounded-lg p-4 flex items-center gap-2">
+          <AlertTriangleIcon className="size-5 text-destructive" />
+          <span className="text-sm font-medium text-destructive">
+            This transaction contains unexpected messages! Review carefully before signing.
+          </span>
+        </div>
+      )}
+
+      <div className="flex items-center">
+        <div className="flex flex-col gap-2 flex-1">
+          <span className="text-muted-foreground text-sm">Primary Amount</span>
+          <span className="text-2xl">{getMessageAmount(primaryMessage)}</span>
+        </div>
+        <div className="w-[1px] h-16 bg-secondary mx-10" />
+        <div className="flex flex-col gap-2 flex-1">
+          <span className="text-muted-foreground text-sm">Validator</span>
+          <span className="text-2xl">
+            {getMessageValidator(primaryMessage) === '-' ? (
+              '-'
+            ) : (
+              <Address address={getMessageValidator(primaryMessage)} />
+            )}
+          </span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col">
+          <div className="rounded-t-lg overflow-hidden border flex md:flex-row flex-col">
+            <div className="flex w-full md:w-2/5 bg-secondary justify-between items-center p-3 text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <UserIcon className="size-4" />
+                <span className="text-sm text-muted-foreground">Delegator</span>
+              </div>
+              <span className="text-sm text-muted-foreground">-</span>
+            </div>
+            <div className="p-3 border-l flex-1 w-full bg-secondary/10">
+              {getMessageAccount(primaryMessage) === '-' ? (
+                '-'
+              ) : (
+                <Address address={getMessageAccount(primaryMessage)} />
+              )}
+            </div>
+          </div>
+          <div className="rounded-b-lg overflow-hidden border flex md:flex-row flex-col">
+            <div className="flex w-full md:w-2/5 bg-secondary justify-between items-center p-3 text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <ArrowLeftRightIcon className="size-4" />
+                <span className="text-sm truncate whitespace-nowrap">Message Type</span>
+              </div>
+              <span className="text-sm">-</span>
+            </div>
+            <div className="p-3 border-l flex-1 w-full bg-secondary/10">
+              <Badge variant={isExpectedMessage(primaryMessage) ? 'success' : 'destructive'}>
+                {getMessageLabel(primaryMessage)}
+              </Badge>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col">
+          <div className="rounded-t-lg overflow-hidden border flex md:flex-row flex-col">
+            <div className="flex w-full md:w-2/5 bg-secondary justify-between items-center p-3 text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <ArrowLeftRightIcon className="size-4" />
+                <span className="text-sm text-muted-foreground">Messages Count</span>
+              </div>
+              <span className="text-sm text-muted-foreground">-</span>
+            </div>
+            <div className="p-3 border-l overflow-auto flex-1 w-full bg-secondary/10">
+              <span className="text-sm font-mono">{transaction.messages.length}</span>
+            </div>
+          </div>
+          <div className="rounded-b-lg overflow-hidden border flex md:flex-row flex-col">
+            <div className="flex w-full md:w-2/5 bg-secondary justify-between items-center p-3 text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <FuelIcon className="size-4" />
+                <span className="text-sm">Fee</span>
+              </div>
+              <span className="text-sm">-</span>
+            </div>
+            <div className="p-3 border-l flex-1 w-full bg-secondary/10">
+              <Badge variant="success">{transaction.fee ? formatCoins(transaction.fee.amount) : 'N/A'}</Badge>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 items-start">
+        <span className="font-medium uppercase">Messages</span>
+
+        <Table>
+          <TableHeader className="bg-secondary">
+            <TableRow>
+              <TableHead>Message Type</TableHead>
+              <TableHead>Details</TableHead>
+              <TableHead className="text-right">Amount</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {transaction.messages.map((message, index) => (
+              <TableRow key={index} className={!isExpectedMessage(message) ? 'bg-destructive/5' : ''}>
+                <TableCell>
+                  <Badge variant={isExpectedMessage(message) ? 'success' : 'destructive'}>
+                    {getMessageLabel(message)}
+                  </Badge>
+                </TableCell>
+                <TableCell className="font-mono text-xs break-all">{getMessageDetails(message)}</TableCell>
+                <TableCell className="text-right font-mono">{getMessageAmount(message)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex flex-col gap-2 items-start">
+        <span className="font-medium uppercase">Technical Details</span>
+
+        <Table>
+          <TableHeader className="bg-secondary">
+            <TableRow>
+              <TableHead>Field</TableHead>
+              <TableHead className="text-right">Value</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow>
+              <TableCell>Memo</TableCell>
+              <TableCell className="text-right break-all font-mono text-xs">{transaction.memo || '-'}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Fee</TableCell>
+              <TableCell className="text-right break-all font-mono text-xs">
+                {transaction.fee ? formatCoins(transaction.fee.amount) : '-'}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Gas Limit</TableCell>
+              <TableCell className="text-right font-mono">{transaction.fee?.gasLimit ?? '-'}</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/packages/cosmos-shared/src/cosmos-adapter.test.ts
+++ b/packages/cosmos-shared/src/cosmos-adapter.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import { MsgDelegate } from 'cosmjs-types/cosmos/staking/v1beta1/tx';
+import { AuthInfo, TxBody, TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
+import type { Any } from 'cosmjs-types/google/protobuf/any';
+import { createCosmosAdapter } from './cosmos-adapter';
+
+const toHex = (bytes: Uint8Array): string =>
+  Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+
+const encodeTx = (messages: Any[]): string => {
+  const bodyBytes = TxBody.encode(TxBody.fromPartial({ messages })).finish();
+  const authInfoBytes = AuthInfo.encode(AuthInfo.fromPartial({})).finish();
+  return toHex(TxRaw.encode(TxRaw.fromPartial({ bodyBytes, authInfoBytes, signatures: [] })).finish());
+};
+
+// A dummy protocol shape — generateWarnings/parseTransaction don't read it.
+const adapter = createCosmosAdapter({
+  name: 'atom',
+  displayName: 'Cosmos',
+  protocol: { name: 'atom' } as never,
+});
+
+describe('createCosmosAdapter warnings', () => {
+  test('an unknown typeUrl yields a warning', async () => {
+    const hex = encodeTx([{ typeUrl: '/cosmos.gov.v1beta1.MsgVote', value: new Uint8Array([9, 9]) }]);
+    const data = await adapter.parseTransaction(hex);
+
+    const warnings = adapter.generateWarnings?.(data) ?? [];
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain('Unsupported message type');
+    expect(warnings[0].message).toContain('/cosmos.gov.v1beta1.MsgVote');
+  });
+
+  test('a plain delegation produces no warnings', async () => {
+    const hex = encodeTx([
+      {
+        typeUrl: '/cosmos.staking.v1beta1.MsgDelegate',
+        value: MsgDelegate.encode(
+          MsgDelegate.fromPartial({
+            delegatorAddress: 'cosmos1d',
+            validatorAddress: 'cosmosvaloper1v',
+            amount: { denom: 'uatom', amount: '1' },
+          }),
+        ).finish(),
+      },
+    ]);
+    const data = await adapter.parseTransaction(hex);
+
+    expect(adapter.generateWarnings?.(data) ?? []).toHaveLength(0);
+  });
+});

--- a/packages/cosmos-shared/src/cosmos-adapter.tsx
+++ b/packages/cosmos-shared/src/cosmos-adapter.tsx
@@ -1,6 +1,6 @@
-import type { DecodedTxRaw } from '@cosmjs/proto-signing';
 import type { Protocol, ProtocolAdapter } from '@protocols/shared';
-import { parseCosmosTx } from './parser';
+import { CosmosTransactionSummary } from './CosmosTransactionSummary';
+import { type CosmosMessage, type CosmosTransaction, parseCosmosTx } from './parser';
 
 const isValidCosmosInput = (rawTx: string): boolean => {
   const input = rawTx.trim();
@@ -22,6 +22,31 @@ const computeCosmosHash = async (rawTx: string): Promise<string> => {
   }
 };
 
+const warningsForMessage = (message: CosmosMessage): string[] => {
+  switch (message.kind) {
+    case 'unsupported':
+      return [`🚨 CRITICAL: Unsupported message type detected: ${message.typeUrl || 'unknown'}`];
+    case 'send':
+      return [`⚠️ Token transfer (MsgSend) detected to ${message.toAddress} — unusual for a staking operation`];
+    case 'redelegate':
+      return [
+        `⚠️ Redelegation detected: moving stake from ${message.validatorSrcAddress} to ${message.validatorDstAddress}`,
+      ];
+    case 'authzGrant':
+      return [
+        `🚨 CRITICAL: Authz grant detected — granting ${message.grantee} authorization ${message.authorizationType}`,
+      ];
+    case 'authzExec':
+      return [
+        `🚨 CRITICAL: Authz exec detected — ${message.grantee} executing ${message.innerTypeUrls.length} nested message(s)`,
+      ];
+    case 'authzRevoke':
+      return [`⚠️ Authz revoke detected for ${message.grantee} (${message.msgTypeUrl})`];
+    default:
+      return [];
+  }
+};
+
 export const createCosmosAdapter = ({
   name,
   displayName,
@@ -30,15 +55,16 @@ export const createCosmosAdapter = ({
   name: string;
   displayName: string;
   protocol: Protocol;
-}): ProtocolAdapter<DecodedTxRaw> => {
+}): ProtocolAdapter<CosmosTransaction> => {
   return {
     protocol,
     name,
     displayName,
     placeholder: 'Paste your transaction as hex',
     validateInput: isValidCosmosInput,
-    convertBigInt: true,
     parseTransaction: async (rawTx) => parseCosmosTx(rawTx),
     computeHash: computeCosmosHash,
+    renderSummary: (data) => <CosmosTransactionSummary transaction={data} />,
+    generateWarnings: (data) => data.messages.flatMap(warningsForMessage).map((message) => ({ message })),
   };
 };

--- a/packages/cosmos-shared/src/index.ts
+++ b/packages/cosmos-shared/src/index.ts
@@ -1,2 +1,3 @@
+export * from './CosmosTransactionSummary';
 export * from './cosmos-adapter';
 export * from './parser';

--- a/packages/cosmos-shared/src/parser.test.ts
+++ b/packages/cosmos-shared/src/parser.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test';
+import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx';
+import { MsgDelegate } from 'cosmjs-types/cosmos/staking/v1beta1/tx';
+import { AuthInfo, TxBody, TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
+import type { Any } from 'cosmjs-types/google/protobuf/any';
+import { parseCosmosTx } from './parser';
+
+const toHex = (bytes: Uint8Array): string =>
+  Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+
+// Encode a minimal signed-tx envelope around the given messages, mirroring the
+// real TxRaw bytes the decoder receives from a Fireblocks raw-signing payload.
+const encodeTx = (messages: Any[], memo = ''): string => {
+  const bodyBytes = TxBody.encode(TxBody.fromPartial({ messages, memo })).finish();
+  const authInfoBytes = AuthInfo.encode(
+    AuthInfo.fromPartial({ fee: { amount: [{ denom: 'uatom', amount: '5000' }], gasLimit: 200000n } }),
+  ).finish();
+  const txRaw = TxRaw.encode(TxRaw.fromPartial({ bodyBytes, authInfoBytes, signatures: [] })).finish();
+  return toHex(txRaw);
+};
+
+const delegateMsg = (validatorAddress: string, delegatorAddress = 'cosmos1delegator', amount = '1000000'): Any => ({
+  typeUrl: '/cosmos.staking.v1beta1.MsgDelegate',
+  value: MsgDelegate.encode(
+    MsgDelegate.fromPartial({ delegatorAddress, validatorAddress, amount: { denom: 'uatom', amount } }),
+  ).finish(),
+});
+
+describe('parseCosmosTx', () => {
+  test('decodes a MsgDelegate into validator, delegator and amount', async () => {
+    const hex = encodeTx([delegateMsg('cosmosvaloper1validator')]);
+
+    const tx = await parseCosmosTx(hex);
+
+    expect(tx.messages).toHaveLength(1);
+    const message = tx.messages[0];
+    expect(message.kind).toBe('delegate');
+    if (message.kind !== 'delegate') throw new Error('expected delegate');
+    expect(message.delegatorAddress).toBe('cosmos1delegator');
+    expect(message.validatorAddress).toBe('cosmosvaloper1validator');
+    expect(message.amount).toEqual({ denom: 'uatom', amount: '1000000' });
+    expect(tx.fee).toEqual({
+      amount: [{ denom: 'uatom', amount: '5000' }],
+      gasLimit: '200000',
+      payer: '',
+      granter: '',
+    });
+  });
+
+  test('two delegations differing only in validator parse to different validatorAddress', async () => {
+    const a = await parseCosmosTx(encodeTx([delegateMsg('cosmosvaloper1AAA')]));
+    const b = await parseCosmosTx(encodeTx([delegateMsg('cosmosvaloper1BBB')]));
+
+    const msgA = a.messages[0];
+    const msgB = b.messages[0];
+    if (msgA.kind !== 'delegate' || msgB.kind !== 'delegate') throw new Error('expected delegate');
+    expect(msgA.validatorAddress).toBe('cosmosvaloper1AAA');
+    expect(msgB.validatorAddress).toBe('cosmosvaloper1BBB');
+    expect(msgA.validatorAddress).not.toBe(msgB.validatorAddress);
+  });
+
+  test('an unknown typeUrl fails closed as unsupported', async () => {
+    const unknown: Any = {
+      typeUrl: '/cosmos.gov.v1beta1.MsgVote',
+      value: new Uint8Array([1, 2, 3, 4]),
+    };
+    const tx = await parseCosmosTx(encodeTx([unknown]));
+
+    const message = tx.messages[0];
+    expect(message.kind).toBe('unsupported');
+    if (message.kind !== 'unsupported') throw new Error('expected unsupported');
+    expect(message.typeUrl).toBe('/cosmos.gov.v1beta1.MsgVote');
+    expect(message.raw).toBe('01020304');
+  });
+
+  test('decodes a MsgSend with its recipient and coins', async () => {
+    const send: Any = {
+      typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+      value: MsgSend.encode(
+        MsgSend.fromPartial({
+          fromAddress: 'cosmos1from',
+          toAddress: 'cosmos1to',
+          amount: [{ denom: 'uatom', amount: '42' }],
+        }),
+      ).finish(),
+    };
+    const tx = await parseCosmosTx(encodeTx([send]));
+
+    const message = tx.messages[0];
+    expect(message.kind).toBe('send');
+    if (message.kind !== 'send') throw new Error('expected send');
+    expect(message.toAddress).toBe('cosmos1to');
+    expect(message.amount).toEqual([{ denom: 'uatom', amount: '42' }]);
+  });
+});

--- a/packages/cosmos-shared/src/parser.test.ts
+++ b/packages/cosmos-shared/src/parser.test.ts
@@ -49,6 +49,22 @@ describe('parseCosmosTx', () => {
     });
   });
 
+  test('trims surrounding whitespace so decoding matches the hashed bytes', async () => {
+    const hex = encodeTx([delegateMsg('cosmosvaloper1validator')]);
+
+    const tx = await parseCosmosTx(`  \n${hex}\n  `);
+
+    const message = tx.messages[0];
+    expect(message.kind).toBe('delegate');
+    if (message.kind !== 'delegate') throw new Error('expected delegate');
+    expect(message.validatorAddress).toBe('cosmosvaloper1validator');
+  });
+
+  test('rejects malformed hex instead of decoding garbage', async () => {
+    await expect(parseCosmosTx('not-hex')).rejects.toThrow('Invalid Cosmos transaction hex');
+    await expect(parseCosmosTx('abc')).rejects.toThrow('Invalid Cosmos transaction hex');
+  });
+
   test('two delegations differing only in validator parse to different validatorAddress', async () => {
     const a = await parseCosmosTx(encodeTx([delegateMsg('cosmosvaloper1AAA')]));
     const b = await parseCosmosTx(encodeTx([delegateMsg('cosmosvaloper1BBB')]));

--- a/packages/cosmos-shared/src/parser.ts
+++ b/packages/cosmos-shared/src/parser.ts
@@ -1,7 +1,237 @@
 import { type DecodedTxRaw, decodeTxRaw } from '@cosmjs/proto-signing';
+import { MsgExec, MsgGrant, MsgRevoke } from 'cosmjs-types/cosmos/authz/v1beta1/tx';
+import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx';
+import { MsgWithdrawDelegatorReward } from 'cosmjs-types/cosmos/distribution/v1beta1/tx';
+import { MsgBeginRedelegate, MsgDelegate, MsgUndelegate } from 'cosmjs-types/cosmos/staking/v1beta1/tx';
+import type { Any } from 'cosmjs-types/google/protobuf/any';
 
-export const parseCosmosTx = async (txRaw: string): Promise<DecodedTxRaw> => {
+/** A normalized coin amount, always rendered as decimal strings (never bigint). */
+export type CosmosCoin = {
+  denom: string;
+  amount: string;
+};
+
+/**
+ * Each entry in a `TxBody.messages` array decoded from its protobuf `Any`
+ * into a concrete, human-readable message. Unknown `typeUrl`s fail closed as
+ * `unsupported` so they are never silently presented as benign.
+ */
+export type CosmosMessage =
+  | {
+      kind: 'delegate' | 'undelegate';
+      typeUrl: string;
+      delegatorAddress: string;
+      validatorAddress: string;
+      amount: CosmosCoin | null;
+    }
+  | {
+      kind: 'redelegate';
+      typeUrl: string;
+      delegatorAddress: string;
+      validatorSrcAddress: string;
+      validatorDstAddress: string;
+      amount: CosmosCoin | null;
+    }
+  | {
+      kind: 'withdrawRewards';
+      typeUrl: string;
+      delegatorAddress: string;
+      validatorAddress: string;
+    }
+  | {
+      kind: 'send';
+      typeUrl: string;
+      fromAddress: string;
+      toAddress: string;
+      amount: CosmosCoin[];
+    }
+  | {
+      kind: 'authzGrant';
+      typeUrl: string;
+      granter: string;
+      grantee: string;
+      authorizationType: string;
+    }
+  | {
+      kind: 'authzExec';
+      typeUrl: string;
+      grantee: string;
+      innerTypeUrls: string[];
+    }
+  | {
+      kind: 'authzRevoke';
+      typeUrl: string;
+      granter: string;
+      grantee: string;
+      msgTypeUrl: string;
+    }
+  | {
+      kind: 'unsupported';
+      typeUrl: string;
+      raw: string;
+    };
+
+export type CosmosFee = {
+  amount: CosmosCoin[];
+  gasLimit: string;
+  payer: string;
+  granter: string;
+};
+
+export type CosmosTransaction = {
+  messages: CosmosMessage[];
+  memo: string;
+  fee: CosmosFee | null;
+};
+
+// Type URLs we know how to decode. Anything else is reported as `unsupported`.
+const TYPE_URLS = {
+  delegate: '/cosmos.staking.v1beta1.MsgDelegate',
+  undelegate: '/cosmos.staking.v1beta1.MsgUndelegate',
+  beginRedelegate: '/cosmos.staking.v1beta1.MsgBeginRedelegate',
+  withdrawRewards: '/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward',
+  send: '/cosmos.bank.v1beta1.MsgSend',
+  authzGrant: '/cosmos.authz.v1beta1.MsgGrant',
+  authzExec: '/cosmos.authz.v1beta1.MsgExec',
+  authzRevoke: '/cosmos.authz.v1beta1.MsgRevoke',
+} as const;
+
+const bytesToHex = (bytes: Uint8Array): string =>
+  Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+
+const toCoin = (coin: { denom: string; amount: string } | undefined | null): CosmosCoin | null =>
+  coin ? { denom: coin.denom, amount: coin.amount } : null;
+
+const toCoins = (coins: ReadonlyArray<{ denom: string; amount: string }>): CosmosCoin[] =>
+  coins.map((coin) => ({ denom: coin.denom, amount: coin.amount }));
+
+/**
+ * Decode a single protobuf `Any` message body by its `typeUrl`. All values are
+ * derived from the raw bytes (`message.value`) — never from any envelope-level
+ * hint — so a mismatched/forged `typeUrl` cannot misrepresent the payload.
+ */
+const decodeMessage = (message: Any): CosmosMessage => {
+  const { typeUrl, value } = message;
+
+  try {
+    switch (typeUrl) {
+      case TYPE_URLS.delegate: {
+        const msg = MsgDelegate.decode(value);
+        return {
+          kind: 'delegate',
+          typeUrl,
+          delegatorAddress: msg.delegatorAddress,
+          validatorAddress: msg.validatorAddress,
+          amount: toCoin(msg.amount),
+        };
+      }
+      case TYPE_URLS.undelegate: {
+        const msg = MsgUndelegate.decode(value);
+        return {
+          kind: 'undelegate',
+          typeUrl,
+          delegatorAddress: msg.delegatorAddress,
+          validatorAddress: msg.validatorAddress,
+          amount: toCoin(msg.amount),
+        };
+      }
+      case TYPE_URLS.beginRedelegate: {
+        const msg = MsgBeginRedelegate.decode(value);
+        return {
+          kind: 'redelegate',
+          typeUrl,
+          delegatorAddress: msg.delegatorAddress,
+          validatorSrcAddress: msg.validatorSrcAddress,
+          validatorDstAddress: msg.validatorDstAddress,
+          amount: toCoin(msg.amount),
+        };
+      }
+      case TYPE_URLS.withdrawRewards: {
+        const msg = MsgWithdrawDelegatorReward.decode(value);
+        return {
+          kind: 'withdrawRewards',
+          typeUrl,
+          delegatorAddress: msg.delegatorAddress,
+          validatorAddress: msg.validatorAddress,
+        };
+      }
+      case TYPE_URLS.send: {
+        const msg = MsgSend.decode(value);
+        return {
+          kind: 'send',
+          typeUrl,
+          fromAddress: msg.fromAddress,
+          toAddress: msg.toAddress,
+          amount: toCoins(msg.amount),
+        };
+      }
+      case TYPE_URLS.authzGrant: {
+        const msg = MsgGrant.decode(value);
+        return {
+          kind: 'authzGrant',
+          typeUrl,
+          granter: msg.granter,
+          grantee: msg.grantee,
+          authorizationType: msg.grant?.authorization?.typeUrl ?? 'unknown',
+        };
+      }
+      case TYPE_URLS.authzExec: {
+        const msg = MsgExec.decode(value);
+        return {
+          kind: 'authzExec',
+          typeUrl,
+          grantee: msg.grantee,
+          innerTypeUrls: msg.msgs.map((inner) => inner.typeUrl),
+        };
+      }
+      case TYPE_URLS.authzRevoke: {
+        const msg = MsgRevoke.decode(value);
+        return {
+          kind: 'authzRevoke',
+          typeUrl,
+          granter: msg.granter,
+          grantee: msg.grantee,
+          msgTypeUrl: msg.msgTypeUrl,
+        };
+      }
+      default:
+        // Fail closed: an unknown type is surfaced explicitly, never as benign.
+        return {
+          kind: 'unsupported',
+          typeUrl,
+          raw: bytesToHex(value),
+        };
+    }
+  } catch {
+    // A declared type whose bytes don't actually decode is also untrustworthy.
+    return {
+      kind: 'unsupported',
+      typeUrl,
+      raw: bytesToHex(value),
+    };
+  }
+};
+
+const decodeFee = (tx: DecodedTxRaw): CosmosFee | null => {
+  const fee = tx.authInfo.fee;
+  if (!fee) return null;
+  return {
+    amount: toCoins(fee.amount),
+    gasLimit: fee.gasLimit.toString(),
+    payer: fee.payer,
+    granter: fee.granter,
+  };
+};
+
+export const parseCosmosTx = async (txRaw: string): Promise<CosmosTransaction> => {
   const bytes = new Uint8Array(txRaw.match(/.{1,2}/g)?.map((byte) => parseInt(byte, 16)) || []);
   const tx = decodeTxRaw(bytes);
-  return tx;
+
+  return {
+    messages: tx.body.messages.map(decodeMessage),
+    memo: tx.body.memo,
+    fee: decodeFee(tx),
+  };
 };

--- a/packages/cosmos-shared/src/parser.ts
+++ b/packages/cosmos-shared/src/parser.ts
@@ -225,8 +225,18 @@ const decodeFee = (tx: DecodedTxRaw): CosmosFee | null => {
   };
 };
 
+const hexToBytes = (hex: string): Uint8Array => {
+  // Canonicalize the same way validateInput/computeHash do, so decoding and
+  // hashing operate on identical bytes and malformed hex fails closed.
+  const input = hex.trim();
+  if (!/^[0-9a-fA-F]*$/.test(input) || input.length % 2 !== 0) {
+    throw new Error('Invalid Cosmos transaction hex');
+  }
+  return new Uint8Array(input.match(/.{1,2}/g)?.map((byte) => parseInt(byte, 16)) || []);
+};
+
 export const parseCosmosTx = async (txRaw: string): Promise<CosmosTransaction> => {
-  const bytes = new Uint8Array(txRaw.match(/.{1,2}/g)?.map((byte) => parseInt(byte, 16)) || []);
+  const bytes = hexToBytes(txRaw);
   const tx = decodeTxRaw(bytes);
 
   return {

--- a/packages/cosmos-shared/tsconfig.json
+++ b/packages/cosmos-shared/tsconfig.json
@@ -3,8 +3,10 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@protocols/shared": ["../shared/src"]
+      "@protocols/shared": ["../shared/src"],
+      "@protocols/ui": ["../ui/src"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Problem

For all 11 Cosmos-family Minitel apps (`atom`, `dydx`, `kava`, `sei`, `tia`, `zeta`, `cronos`, `fetch`, `injective`, `mantra`, `osmosis`), `parseCosmosTx` only decoded the `TxRaw`/`TxBody`/`AuthInfo` envelope. Each `body.messages[i]` stayed a protobuf `Any`, so `validatorAddress`, `delegatorAddress`, and the staked `amount`/`denom` were only visible as raw bytes. The shared adapter exposed neither `renderSummary` nor `generateWarnings`, so the UI fell back to a JSON-only view rendering the byte array as a numeric-key object.

A user following Kiln's documented Fireblocks raw-signing workflow could not verify the destination validator or staked amount before approving.

## Fix (once, in `packages/cosmos-shared`)

- **`parser.ts`** — unpack each `Any.value` by `typeUrl` into a concrete `CosmosMessage`, deriving all values from the raw bytes (same principle as #62). Covers staking (`MsgDelegate`/`MsgUndelegate`/`MsgBeginRedelegate`), distribution rewards, `bank.MsgSend`, and authz (`MsgGrant`/`MsgExec`/`MsgRevoke`). Unknown type URLs — and declared types whose bytes fail to decode — **fail closed** as `unsupported`. Output is fully string-based (no bigints).
- **`cosmos-adapter.tsx`** — add `renderSummary` + `generateWarnings`. Warnings flag unsupported types, sends, authz grants/execs, and redelegations.
- **`CosmosTransactionSummary.tsx`** — new component cloned from the NEAR summary, reusing `Address`/`Badge`/`Table*` from `@protocols/ui`. Surfaces message type, delegator, validator, amount/denom, fee, and memo.
- **`cosmjs-types`** promoted from a transitive dep of `@cosmjs/proto-signing` to a direct dependency (no new code added to the tree).

## Tests

`bun test` (6 pass): decoded `MsgDelegate` exposes validator/delegator/amount; two delegations differing only in validator parse to different `validatorAddress`; an unknown `typeUrl` yields `unsupported` + a warning; plus `MsgSend` decoding.