### PR TITLE
feat: require a Kiln-operation verdict from every decoder

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,10 @@ jobs:
       contents: read
       deployments: write
     strategy:
+      # One app's failure must not cancel the other seventeen: with fail-fast on, the
+      # first job to fail hid the state of every other deploy, so a single broken app
+      # read as "the deploy is broken" and the ones that would have shipped never ran.
+      fail-fast: false
       matrix:
         app: [ethereum, solana, near, zeta, tia, sei, osmosis, injective, fetch, dydx, cronos, atom, kava, ada, sui, xtz, ton, trx]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun test

--- a/apps/ada/src/ada-adapter.ts
+++ b/apps/ada/src/ada-adapter.ts
@@ -1,7 +1,7 @@
 import type { TransactionJSON } from '@emurgo/cardano-serialization-lib-browser';
 import { Transaction, TransactionBody } from '@emurgo/cardano-serialization-lib-browser';
 import { blake2b } from '@noble/hashes/blake2.js';
-import { ADA, type ProtocolAdapter } from '@protocols/shared';
+import { ADA, type ProtocolAdapter, pendingAllowlist } from '@protocols/shared';
 import { parseAdaTx } from '@/parser';
 
 const isValidAdaInput = (rawTx: string): boolean => {
@@ -42,4 +42,6 @@ export const adaAdapter: ProtocolAdapter<TransactionJSON> = {
   validateInput: isValidAdaInput,
   parseTransaction: parseAdaTx,
   computeHash: computeAdaHash,
+  // Kiln crafts stake, unstake and withdraw-rewards on Cardano — allowlist not written yet.
+  classifyTransaction: pendingAllowlist,
 };

--- a/apps/ada/src/ada-adapter.ts
+++ b/apps/ada/src/ada-adapter.ts
@@ -1,7 +1,8 @@
 import type { TransactionJSON } from '@emurgo/cardano-serialization-lib-browser';
 import { Transaction, TransactionBody } from '@emurgo/cardano-serialization-lib-browser';
 import { blake2b } from '@noble/hashes/blake2.js';
-import { ADA, type ProtocolAdapter, pendingAllowlist } from '@protocols/shared';
+import { ADA, type ProtocolAdapter } from '@protocols/shared';
+import { classifyAdaTransaction } from '@/kiln-operations';
 import { parseAdaTx } from '@/parser';
 
 const isValidAdaInput = (rawTx: string): boolean => {
@@ -42,6 +43,5 @@ export const adaAdapter: ProtocolAdapter<TransactionJSON> = {
   validateInput: isValidAdaInput,
   parseTransaction: parseAdaTx,
   computeHash: computeAdaHash,
-  // Kiln crafts stake, unstake and withdraw-rewards on Cardano — allowlist not written yet.
-  classifyTransaction: pendingAllowlist,
+  classifyTransaction: classifyAdaTransaction,
 };

--- a/apps/ada/src/kiln-operations.test.ts
+++ b/apps/ada/src/kiln-operations.test.ts
@@ -3,10 +3,8 @@ import type { CertificateJSON, TransactionJSON } from '@emurgo/cardano-serializa
 import { classifyAdaTransaction } from '@/kiln-operations';
 
 /**
- * These build the decoded JSON directly rather than round-tripping through the serialization
- * library: its browser WASM build does not initialize under the test runner, so a real
- * transaction cannot be forged here. The shapes below follow CertificateJSON and
- * TransactionBodyJSON, which is what the parser hands the classifier.
+ * Built as decoded JSON rather than forged: the serialization library's browser WASM build does
+ * not initialize under the test runner. Shapes follow CertificateJSON and TransactionBodyJSON.
  */
 
 const keyCredential = { Key: '00'.repeat(28) };

--- a/apps/ada/src/kiln-operations.test.ts
+++ b/apps/ada/src/kiln-operations.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test';
+import type { CertificateJSON, TransactionJSON } from '@emurgo/cardano-serialization-lib-browser';
+import { classifyAdaTransaction } from '@/kiln-operations';
+
+/**
+ * These build the decoded JSON directly rather than round-tripping through the serialization
+ * library: its browser WASM build does not initialize under the test runner, so a real
+ * transaction cannot be forged here. The shapes below follow CertificateJSON and
+ * TransactionBodyJSON, which is what the parser hands the classifier.
+ */
+
+const keyCredential = { Key: '00'.repeat(28) };
+const poolKeyhash = '11'.repeat(28);
+const rewardAddress = `e0${'22'.repeat(28)}`;
+
+const tx = ({
+  certs,
+  withdrawals,
+  ...rest
+}: {
+  certs?: CertificateJSON[];
+  withdrawals?: Record<string, string>;
+  mint?: unknown;
+  voting_proposals?: unknown[];
+}): TransactionJSON =>
+  ({
+    body: {
+      inputs: [],
+      outputs: [],
+      fee: '200000',
+      ...(certs ? { certs } : {}),
+      ...(withdrawals ? { withdrawals } : {}),
+      ...rest,
+    },
+    witness_set: { vkeys: [] },
+    is_valid: true,
+  }) as TransactionJSON;
+
+const stakeRegistration = { StakeRegistration: { stake_credential: keyCredential } } as CertificateJSON;
+const stakeAndVoteDelegation = {
+  StakeAndVoteDelegation: { stake_credential: keyCredential, pool_keyhash: poolKeyhash, drep: 'AlwaysAbstain' },
+} as CertificateJSON;
+const stakeDeregistration = { StakeDeregistration: { stake_credential: keyCredential } } as CertificateJSON;
+
+describe('Kiln Cardano operations are recognized', () => {
+  test('stake — a first-time key registers and delegates', () => {
+    const verdict = classifyAdaTransaction(tx({ certs: [stakeRegistration, stakeAndVoteDelegation] }));
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'stake' });
+  });
+
+  test('stake — an already-registered key just delegates', () => {
+    const verdict = classifyAdaTransaction(tx({ certs: [stakeAndVoteDelegation] }));
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'stake' });
+  });
+
+  test('unstake — deregistration sweeping the outstanding rewards', () => {
+    const verdict = classifyAdaTransaction(
+      tx({ certs: [stakeDeregistration], withdrawals: { [rewardAddress]: '4200000' } }),
+    );
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'unstake' });
+  });
+
+  test('withdraw-rewards — a withdrawals map and no certificate', () => {
+    const verdict = classifyAdaTransaction(tx({ withdrawals: { [rewardAddress]: '4200000' } }));
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'withdraw-rewards' });
+  });
+});
+
+describe('Non-Kiln Cardano transactions are rejected', () => {
+  test('a plain transfer with neither certificate nor withdrawal', () => {
+    const verdict = classifyAdaTransaction(tx({}));
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('plain transfer') });
+  });
+
+  test('registering a stake pool', () => {
+    const verdict = classifyAdaTransaction(
+      tx({ certs: [{ PoolRegistration: { pool_params: {} } } as never as CertificateJSON] }),
+    );
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('PoolRegistration') });
+  });
+
+  test('a DRep registration riding alongside a delegation', () => {
+    const verdict = classifyAdaTransaction(
+      tx({
+        certs: [stakeAndVoteDelegation, { DRepRegistration: { voting_credential: keyCredential } } as never],
+      }),
+    );
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('DRepRegistration') });
+  });
+
+  test('a deregistration bundled with a delegation', () => {
+    const verdict = classifyAdaTransaction(tx({ certs: [stakeDeregistration, stakeAndVoteDelegation] }));
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('StakeDeregistration + StakeAndVoteDelegation') });
+  });
+
+  test('a token mint alongside a valid delegation', () => {
+    const verdict = classifyAdaTransaction(tx({ certs: [stakeAndVoteDelegation], mint: [{ policy: 'x' }] }));
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('mints or burns') });
+  });
+
+  test('a governance proposal alongside a valid delegation', () => {
+    const verdict = classifyAdaTransaction(
+      tx({ certs: [stakeAndVoteDelegation], voting_proposals: [{ deposit: '1' }] }),
+    );
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('governance') });
+  });
+});

--- a/apps/ada/src/kiln-operations.ts
+++ b/apps/ada/src/kiln-operations.ts
@@ -2,32 +2,15 @@ import type { CertificateJSON, TransactionJSON } from '@emurgo/cardano-serializa
 import { recognized, type TransactionVerdict, unrecognized } from '@protocols/shared';
 
 /**
- * The Cardano operations Kiln crafts, and the certificates each one carries.
- *
- * Source of truth is Kiln's transaction-crafting API, which the public Kiln Connect spec
- * exposes as `/ada/transaction/{stake,unstake,withdraw-rewards}`:
- *
- * - stake — a stake-and-vote delegation, preceded by a stake registration the first time the
- *   key is used. A key already registered is delegated without re-registering, so both the
- *   one- and two-certificate forms are genuine.
- * - unstake — a stake deregistration, which also sweeps the outstanding rewards, so the
- *   withdrawals map is populated alongside the certificate.
- * - withdraw-rewards — a withdrawals map and no certificate at all.
- *
- * Matching is on certificate shape, not on the pool being delegated to. The pool id lives in
- * Kiln's configuration and changes without minitel knowing; baking it in here would produce a
- * list that goes stale and starts rejecting real transactions. The decoded summary below the
- * verdict is where the user checks which pool they are delegating to.
+ * Kiln's Cardano routes: stake is a delegation, preceded by a registration the first time a
+ * key is used; unstake is a deregistration; withdraw-rewards is a bare withdrawals map.
+ * Matched on certificate shape, not on the pool id, which is Kiln configuration.
  */
 
 /** Certificates are single-key objects tagged by variant, e.g. `{ StakeDelegation: {...} }`. */
 const certificateKind = (certificate: CertificateJSON): string => Object.keys(certificate)[0] ?? 'unknown';
 
-/**
- * The delegation certificates Kiln's stake route may produce. The Conway era split delegation
- * into several variants depending on whether a governance vote is delegated at the same time,
- * and whether registration is folded into the same certificate.
- */
+/** Conway split delegation into variants by whether a vote or registration rides along. */
 const DELEGATION_CERTIFICATES = new Set([
   'StakeDelegation',
   'StakeAndVoteDelegation',
@@ -44,8 +27,7 @@ export const classifyAdaTransaction = (transaction: TransactionJSON): Transactio
     return unrecognized('This transaction has no body to inspect.');
   }
 
-  // A staking operation never mints or burns, and never carries governance proposals. These
-  // ride alongside the certificates rather than replacing them, so they are checked first.
+  // These ride alongside the certificates rather than replacing them, so check them first.
   if (body.mint) {
     return unrecognized('This transaction mints or burns tokens, which no Kiln operation does.');
   }

--- a/apps/ada/src/kiln-operations.ts
+++ b/apps/ada/src/kiln-operations.ts
@@ -1,0 +1,83 @@
+import type { CertificateJSON, TransactionJSON } from '@emurgo/cardano-serialization-lib-browser';
+import { recognized, type TransactionVerdict, unrecognized } from '@protocols/shared';
+
+/**
+ * The Cardano operations Kiln crafts, and the certificates each one carries.
+ *
+ * Source of truth is Kiln's transaction-crafting API, which the public Kiln Connect spec
+ * exposes as `/ada/transaction/{stake,unstake,withdraw-rewards}`:
+ *
+ * - stake — a stake-and-vote delegation, preceded by a stake registration the first time the
+ *   key is used. A key already registered is delegated without re-registering, so both the
+ *   one- and two-certificate forms are genuine.
+ * - unstake — a stake deregistration, which also sweeps the outstanding rewards, so the
+ *   withdrawals map is populated alongside the certificate.
+ * - withdraw-rewards — a withdrawals map and no certificate at all.
+ *
+ * Matching is on certificate shape, not on the pool being delegated to. The pool id lives in
+ * Kiln's configuration and changes without minitel knowing; baking it in here would produce a
+ * list that goes stale and starts rejecting real transactions. The decoded summary below the
+ * verdict is where the user checks which pool they are delegating to.
+ */
+
+/** Certificates are single-key objects tagged by variant, e.g. `{ StakeDelegation: {...} }`. */
+const certificateKind = (certificate: CertificateJSON): string => Object.keys(certificate)[0] ?? 'unknown';
+
+/**
+ * The delegation certificates Kiln's stake route may produce. The Conway era split delegation
+ * into several variants depending on whether a governance vote is delegated at the same time,
+ * and whether registration is folded into the same certificate.
+ */
+const DELEGATION_CERTIFICATES = new Set([
+  'StakeDelegation',
+  'StakeAndVoteDelegation',
+  'StakeRegistrationAndDelegation',
+  'StakeVoteRegistrationAndDelegation',
+]);
+
+const asSequence = (kinds: string[]): string => kinds.join(' + ');
+
+export const classifyAdaTransaction = (transaction: TransactionJSON): TransactionVerdict => {
+  const body = transaction?.body;
+
+  if (!body) {
+    return unrecognized('This transaction has no body to inspect.');
+  }
+
+  // A staking operation never mints or burns, and never carries governance proposals. These
+  // ride alongside the certificates rather than replacing them, so they are checked first.
+  if (body.mint) {
+    return unrecognized('This transaction mints or burns tokens, which no Kiln operation does.');
+  }
+  if (body.voting_proposals?.length || body.voting_procedures?.length) {
+    return unrecognized('This transaction submits a governance vote or proposal, which no Kiln operation does.');
+  }
+
+  const certificates = body.certs ?? [];
+  const kinds = certificates.map(certificateKind);
+  const withdrawsRewards = Object.keys(body.withdrawals ?? {}).length > 0;
+
+  if (kinds.length === 0) {
+    return withdrawsRewards
+      ? recognized('withdraw-rewards')
+      : unrecognized(
+          'This transaction carries no staking certificate and withdraws no rewards, so it is a plain transfer rather than a Kiln operation.',
+        );
+  }
+
+  if (kinds.length === 1 && kinds[0] === 'StakeDeregistration') {
+    return recognized('unstake');
+  }
+
+  if (kinds.length === 1 && DELEGATION_CERTIFICATES.has(kinds[0])) {
+    return recognized('stake');
+  }
+
+  if (kinds.length === 2 && kinds[0] === 'StakeRegistration' && DELEGATION_CERTIFICATES.has(kinds[1])) {
+    return recognized('stake');
+  }
+
+  return unrecognized(
+    `This transaction carries ${asSequence(kinds)}, which is not a certificate sequence Kiln produces on Cardano.`,
+  );
+};

--- a/apps/ada/src/parser.ts
+++ b/apps/ada/src/parser.ts
@@ -1,18 +1,24 @@
 import type { TransactionJSON } from '@emurgo/cardano-serialization-lib-browser';
 import { Transaction, TransactionBody } from '@emurgo/cardano-serialization-lib-browser';
 
+/**
+ * `to_js_value()` silently omits the withdrawals map, so a reward withdrawal used to decode as a
+ * transaction that did nothing at all — and an unstake showed its deregistration certificate
+ * with no sign of the rewards being moved. `to_json()` carries the whole body, so both are
+ * derived from it instead.
+ */
+const toJson = (value: { to_json: () => string }): TransactionJSON => JSON.parse(value.to_json());
+
 export const parseAdaTx = async (txRaw: string): Promise<TransactionJSON> => {
   try {
     // First try to parse as complete transaction
     try {
-      const tx = Transaction.from_hex(txRaw);
-      return tx.to_js_value();
+      return toJson(Transaction.from_hex(txRaw));
     } catch {
       const txBody = TransactionBody.from_hex(txRaw);
-      const bodyJson = txBody.to_js_value();
 
       return {
-        body: bodyJson,
+        body: JSON.parse(txBody.to_json()),
         witness_set: {
           vkeys: [],
         },

--- a/apps/ada/src/parser.ts
+++ b/apps/ada/src/parser.ts
@@ -1,12 +1,7 @@
 import type { TransactionJSON } from '@emurgo/cardano-serialization-lib-browser';
 import { Transaction, TransactionBody } from '@emurgo/cardano-serialization-lib-browser';
 
-/**
- * `to_js_value()` silently omits the withdrawals map, so a reward withdrawal used to decode as a
- * transaction that did nothing at all — and an unstake showed its deregistration certificate
- * with no sign of the rewards being moved. `to_json()` carries the whole body, so both are
- * derived from it instead.
- */
+/** `to_js_value()` omits the withdrawals map, so a reward withdrawal decoded as doing nothing. */
 const toJson = (value: { to_json: () => string }): TransactionJSON => JSON.parse(value.to_json());
 
 export const parseAdaTx = async (txRaw: string): Promise<TransactionJSON> => {

--- a/apps/ada/tsconfig.json
+++ b/apps/ada/tsconfig.json
@@ -9,5 +9,6 @@
       "@protocols/cosmos-shared": ["../../packages/cosmos-shared/src"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }

--- a/apps/ethereum/src/components/TransactionSummary.tsx
+++ b/apps/ethereum/src/components/TransactionSummary.tsx
@@ -16,11 +16,7 @@ import { classifyEthereumTransaction } from '@/kiln-operations';
 import type { AugmentedTransaction } from '@/types';
 import { ethExplorerLink, getActionDetails } from '@/utils';
 
-/**
- * The verdict is the risk signal. Every action handler used to report 'high', so the badge read
- * HIGH RISK on a routine stake and on a drainer approval alike; a transaction Kiln produces is
- * the expected case and should read as one.
- */
+/** The verdict is the risk signal: a transaction Kiln produces should read as expected. */
 const RISK_BY_VERDICT = {
   recognized: { label: 'EXPECTED', variant: 'success' },
   unverified: { label: 'CHECK DETAILS', variant: 'secondary' },

--- a/apps/ethereum/src/components/TransactionSummary.tsx
+++ b/apps/ethereum/src/components/TransactionSummary.tsx
@@ -12,8 +12,20 @@ import {
 } from '@protocols/ui';
 import { ArrowLeftRightIcon, FuelIcon, ShrinkIcon, TriangleAlertIcon } from 'lucide-react';
 import { formatEther, formatGwei } from 'viem';
+import { classifyEthereumTransaction } from '@/kiln-operations';
 import type { AugmentedTransaction } from '@/types';
 import { ethExplorerLink, getActionDetails } from '@/utils';
+
+/**
+ * The verdict is the risk signal. Every action handler used to report 'high', so the badge read
+ * HIGH RISK on a routine stake and on a drainer approval alike; a transaction Kiln produces is
+ * the expected case and should read as one.
+ */
+const RISK_BY_VERDICT = {
+  recognized: { label: 'EXPECTED', variant: 'success' },
+  unverified: { label: 'CHECK DETAILS', variant: 'secondary' },
+  unrecognized: { label: 'HIGH RISK', variant: 'destructive' },
+} as const;
 
 type TransactionSummaryProps = {
   transaction: AugmentedTransaction;
@@ -23,7 +35,14 @@ export function TransactionSummary({ transaction }: TransactionSummaryProps) {
   if (!transaction) return null;
 
   const actionDetails = getActionDetails(transaction);
-  const riskLevel = actionDetails.riskLevel;
+  const verdict = classifyEthereumTransaction(transaction);
+  const risk = RISK_BY_VERDICT[verdict.status];
+  const transactionType =
+    'inputData' in transaction && transaction.inputData
+      ? transaction.inputData.functionName
+      : (transaction.value ?? 0n) > 0n
+        ? 'ETH transfer'
+        : 'Contract call';
   const ethValue = formatEther(BigInt(transaction.value ?? 0n));
   const maxFeeGwei = Number(formatGwei(transaction.maxFeePerGas ?? 0n)).toFixed(2);
 
@@ -51,12 +70,12 @@ export function TransactionSummary({ transaction }: TransactionSummaryProps) {
             <div className="flex w-full md:w-2/5 bg-secondary justify-between items-center p-3 text-muted-foreground">
               <div className="flex items-center gap-2">
                 <TriangleAlertIcon className="size-4" />
-                <span className="text-sm text-muted-foreground">Risk level</span>
+                <span className="text-sm text-muted-foreground">Assessment</span>
               </div>
               <span className="text-sm text-muted-foreground">-</span>
             </div>
             <div className="p-3 border-l flex-1 w-full bg-secondary/10">
-              <Badge variant="destructive">{riskLevel.toUpperCase()} RISK</Badge>
+              <Badge variant={risk.variant}>{risk.label}</Badge>
             </div>
           </div>
           <div className="rounded-b-lg overflow-hidden border flex md:flex-row flex-col">
@@ -68,7 +87,7 @@ export function TransactionSummary({ transaction }: TransactionSummaryProps) {
               <span className="text-sm">-</span>
             </div>
             <div className="p-3 border-l flex-1 w-full bg-secondary/10">
-              <Badge variant="success">Approval</Badge>
+              <Badge variant="secondary">{transactionType}</Badge>
             </div>
           </div>
         </div>

--- a/apps/ethereum/src/constant.ts
+++ b/apps/ethereum/src/constant.ts
@@ -9,6 +9,16 @@ import { POL_CONTRACT_ABI } from '@/abi/POL_CONTRACT_ABI';
 import { POL_STAKE_MANAGER_ABI } from '@/abi/POL_STAKE_MANAGER_ABI';
 import { POL_VALIDATOR_SHARES_CONTRACT_ABI } from '@/abi/POL_VALIDATOR_SHARES_CONTRACT_ABI';
 
+// Chain IDs on which the hardcoded protocol ABIs (keyed by contract address) are
+// deployed. Protocol-specific decoding must be gated on these so a transaction on
+// another EVM chain that reuses one of these addresses cannot be falsely labeled as
+// a known Ethereum protocol action.
+export const ETHEREUM_CHAIN_IDS: readonly number[] = [
+  1, // mainnet
+  11155111, // sepolia
+  560048, // hoodi
+];
+
 // Contract addresses
 export const CCTP_MESSAGE_TRANSMITTER_ADDRESS = '0x0a992d191deec32afe36203ad87d7d289a738f81' as const;
 export const POL_STAKE_MANAGER_ADDRESS = '0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908' as const;

--- a/apps/ethereum/src/constant.ts
+++ b/apps/ethereum/src/constant.ts
@@ -9,19 +9,16 @@ import { POL_CONTRACT_ABI } from '@/abi/POL_CONTRACT_ABI';
 import { POL_STAKE_MANAGER_ABI } from '@/abi/POL_STAKE_MANAGER_ABI';
 import { POL_VALIDATOR_SHARES_CONTRACT_ABI } from '@/abi/POL_VALIDATOR_SHARES_CONTRACT_ABI';
 
-// Chain IDs on which the hardcoded protocol ABIs (keyed by contract address) are
-// deployed. Protocol-specific decoding must be gated on these so a transaction on
-// another EVM chain that reuses one of these addresses cannot be falsely labeled as
-// a known Ethereum protocol action.
+// Chains the address-keyed protocol ABIs below are deployed on. Decoding is gated on these so
+// a transaction reusing one of those addresses elsewhere is not labeled as an Ethereum action.
 export const ETHEREUM_CHAIN_IDS: readonly number[] = [
   1, // mainnet
   11155111, // sepolia
   560048, // hoodi
 ];
 
-// Chains Kiln's DeFi vaults run on. Unlike the staking contracts above, the vault calls are
-// ERC-4626 and ERC-20 — identified by selector rather than by address — and the product is
-// deliberately multi-chain, so a vault deposit on Base is as genuine as one on mainnet.
+// Chains Kiln's vaults run on. Their calls are ERC-4626 and ERC-20, identified by selector
+// rather than address, and the product is deliberately multi-chain.
 export const DEFI_CHAIN_IDS: readonly number[] = [
   1, // mainnet
   10, // optimism

--- a/apps/ethereum/src/constant.ts
+++ b/apps/ethereum/src/constant.ts
@@ -19,6 +19,21 @@ export const ETHEREUM_CHAIN_IDS: readonly number[] = [
   560048, // hoodi
 ];
 
+// Chains Kiln's DeFi vaults run on. Unlike the staking contracts above, the vault calls are
+// ERC-4626 and ERC-20 — identified by selector rather than by address — and the product is
+// deliberately multi-chain, so a vault deposit on Base is as genuine as one on mainnet.
+export const DEFI_CHAIN_IDS: readonly number[] = [
+  1, // mainnet
+  10, // optimism
+  56, // bnb smart chain
+  137, // polygon
+  8453, // base
+  42161, // arbitrum
+  42220, // celo
+  11155111, // sepolia
+  560048, // hoodi
+];
+
 // Contract addresses
 export const CCTP_MESSAGE_TRANSMITTER_ADDRESS = '0x0a992d191deec32afe36203ad87d7d289a738f81' as const;
 export const POL_STAKE_MANAGER_ADDRESS = '0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908' as const;

--- a/apps/ethereum/src/ethereum-adapter.tsx
+++ b/apps/ethereum/src/ethereum-adapter.tsx
@@ -1,4 +1,4 @@
-import { ETH, type ProtocolAdapter } from '@protocols/shared';
+import { ETH, type ProtocolAdapter, pendingAllowlist } from '@protocols/shared';
 import { formatEther, isHex } from 'viem';
 import * as viemChains from 'viem/chains';
 import { TransactionSummary } from '@/components/TransactionSummary';
@@ -54,6 +54,12 @@ export const ethereumAdapter: ProtocolAdapter<AugmentedTransaction> = {
     { key: 'chainId', type: 'select', options: chains, label: 'Chain ID', placeholder: '1' },
   ],
   buildTransactionFromFields: buildEthTransactionFromFields,
+
+  // Kiln crafts stake, deposit, withdrawal, consolidate, enable-compounding and exit-request
+  // here, plus the DeFi vault and Polygon operations. The address→ABI map in constant.ts is
+  // most of an allowlist already, but it currently falls through to generic ERC20/ERC4626
+  // decoding for anything else, so turning it into a verdict is its own change.
+  classifyTransaction: pendingAllowlist,
 
   generateWarnings: (data) => {
     const valueWei = data.value ?? 0n;

--- a/apps/ethereum/src/ethereum-adapter.tsx
+++ b/apps/ethereum/src/ethereum-adapter.tsx
@@ -5,7 +5,6 @@ import { TransactionSummary } from '@/components/TransactionSummary';
 import { classifyEthereumTransaction } from '@/kiln-operations';
 import { hashEthTx, parseEthTx } from '@/parser';
 import type { AugmentedTransaction } from '@/types';
-import { getActionDetails } from '@/utils';
 
 export const buildEthTransactionFromFields = (fields: Record<string, string>) => {
   const txObject: Record<string, string> = {};
@@ -58,14 +57,11 @@ export const ethereumAdapter: ProtocolAdapter<AugmentedTransaction> = {
 
   classifyTransaction: classifyEthereumTransaction,
 
+  // Only things the verdict and the summary do not already say. The per-function
+  // "X is a high risk operation" strings that used to live here fired on every decoded
+  // transaction, including an empty one, so they read as noise rather than as an alert.
   generateWarnings: (data) => {
-    const valueWei = data.value ?? 0n;
-    const ethAmount = formatEther(valueWei);
-    const isHighValue = Number(ethAmount) > 1;
-    const warnings = [
-      { message: getActionDetails(data).warning },
-      ...(isHighValue ? [{ message: `High value transaction: ${ethAmount} ETH` }] : []),
-    ];
-    return warnings;
+    const ethAmount = formatEther(data.value ?? 0n);
+    return Number(ethAmount) > 1 ? [{ message: `High value transaction: ${ethAmount} ETH` }] : [];
   },
 };

--- a/apps/ethereum/src/ethereum-adapter.tsx
+++ b/apps/ethereum/src/ethereum-adapter.tsx
@@ -57,9 +57,7 @@ export const ethereumAdapter: ProtocolAdapter<AugmentedTransaction> = {
 
   classifyTransaction: classifyEthereumTransaction,
 
-  // Only things the verdict and the summary do not already say. The per-function
-  // "X is a high risk operation" strings that used to live here fired on every decoded
-  // transaction, including an empty one, so they read as noise rather than as an alert.
+  // Only what the verdict and summary do not already say.
   generateWarnings: (data) => {
     const ethAmount = formatEther(data.value ?? 0n);
     return Number(ethAmount) > 1 ? [{ message: `High value transaction: ${ethAmount} ETH` }] : [];

--- a/apps/ethereum/src/ethereum-adapter.tsx
+++ b/apps/ethereum/src/ethereum-adapter.tsx
@@ -1,7 +1,8 @@
-import { ETH, type ProtocolAdapter, pendingAllowlist } from '@protocols/shared';
+import { ETH, type ProtocolAdapter } from '@protocols/shared';
 import { formatEther, isHex } from 'viem';
 import * as viemChains from 'viem/chains';
 import { TransactionSummary } from '@/components/TransactionSummary';
+import { classifyEthereumTransaction } from '@/kiln-operations';
 import { hashEthTx, parseEthTx } from '@/parser';
 import type { AugmentedTransaction } from '@/types';
 import { getActionDetails } from '@/utils';
@@ -55,12 +56,7 @@ export const ethereumAdapter: ProtocolAdapter<AugmentedTransaction> = {
   ],
   buildTransactionFromFields: buildEthTransactionFromFields,
 
-  // Kiln crafts stake, deposit, withdrawal, consolidate, enable-compounding and exit-request
-  // here, plus the DeFi vault and Polygon operations. The address→ABI map in constant.ts is
-  // most of an allowlist already, and it is now gated on chain id (SEC-358), but it still
-  // falls through to generic ERC20/ERC4626 decoding for anything else — so turning it into a
-  // verdict is its own change.
-  classifyTransaction: pendingAllowlist,
+  classifyTransaction: classifyEthereumTransaction,
 
   generateWarnings: (data) => {
     const valueWei = data.value ?? 0n;

--- a/apps/ethereum/src/ethereum-adapter.tsx
+++ b/apps/ethereum/src/ethereum-adapter.tsx
@@ -57,8 +57,9 @@ export const ethereumAdapter: ProtocolAdapter<AugmentedTransaction> = {
 
   // Kiln crafts stake, deposit, withdrawal, consolidate, enable-compounding and exit-request
   // here, plus the DeFi vault and Polygon operations. The address→ABI map in constant.ts is
-  // most of an allowlist already, but it currently falls through to generic ERC20/ERC4626
-  // decoding for anything else, so turning it into a verdict is its own change.
+  // most of an allowlist already, and it is now gated on chain id (SEC-358), but it still
+  // falls through to generic ERC20/ERC4626 decoding for anything else — so turning it into a
+  // verdict is its own change.
   classifyTransaction: pendingAllowlist,
 
   generateWarnings: (data) => {

--- a/apps/ethereum/src/kiln-operations.test.ts
+++ b/apps/ethereum/src/kiln-operations.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from 'bun:test';
+import { concat, encodeFunctionData, numberToHex, parseAbi, serializeTransaction } from 'viem';
+import {
+  EIGENLAYER_DELEGATION_MANAGER_ADDRESS,
+  ETH_BEACON_DEPOSIT_CONTRACT_ADDRESS,
+  ETH_EXIT_CONTRACT_ADDRESS,
+  EXIT_QUEUE_HELPER_ADDRESS,
+  MATIC_STAKE_MANAGER_CONTRACT_ADDRESS,
+} from '@/constant';
+import { classifyEthereumTransaction } from '@/kiln-operations';
+import { parseEthTx } from '@/parser';
+
+/**
+ * The calls below mirror how services/sof/tx builds each operation (EthService, PolService,
+ * MaticService, DefiService), so a change on either side shows up here rather than in
+ * production.
+ */
+
+const WITHDRAWAL_REQUEST_PREDEPLOY = '0x00000961Ef480Eb55e80D19ad83579A64c007002' as const;
+const CONSOLIDATION_REQUEST_PREDEPLOY = '0x0000BBdDc7CE488642fb579F8B00f3a590007251' as const;
+
+const pubkeyA = `0x${'aa'.repeat(48)}` as const;
+const pubkeyB = `0x${'bb'.repeat(48)}` as const;
+
+const serialize = ({
+  chainId = 1,
+  to,
+  data = '0x',
+  value = 0n,
+}: {
+  chainId?: number;
+  to: `0x${string}`;
+  data?: `0x${string}`;
+  value?: bigint;
+}) =>
+  serializeTransaction({
+    type: 'eip1559',
+    chainId,
+    to,
+    data,
+    value,
+    nonce: 0,
+    gas: 200000n,
+    maxFeePerGas: 50000000000n,
+    maxPriorityFeePerGas: 2000000000n,
+  });
+
+/** Serialize, run the real parser, then classify — the whole path a pasted payload takes. */
+const classify = async (args: Parameters<typeof serialize>[0]) =>
+  classifyEthereumTransaction(await parseEthTx(serialize(args)));
+
+const call = (signature: string, functionName: string, args: readonly unknown[]) =>
+  encodeFunctionData({ abi: parseAbi([signature]), functionName, args } as never);
+
+describe('Kiln Ethereum operations are recognized', () => {
+  test('exit-request — requestExit on the exit contract', async () => {
+    const verdict = await classify({
+      to: ETH_EXIT_CONTRACT_ADDRESS,
+      data: call('function requestExit(bytes[] validators_) external', 'requestExit', [[pubkeyA]]),
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'exit-request' });
+  });
+
+  test('exit-request — a single validator goes to the EIP-7002 predeploy with a zero amount', async () => {
+    const verdict = await classify({
+      to: WITHDRAWAL_REQUEST_PREDEPLOY,
+      data: concat([pubkeyA, numberToHex(0, { size: 8 })]),
+      value: 1000n,
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'exit-request' });
+  });
+
+  test('withdrawal — the same predeploy with a non-zero amount', async () => {
+    const verdict = await classify({
+      to: WITHDRAWAL_REQUEST_PREDEPLOY,
+      data: concat([pubkeyA, numberToHex(32000000000n, { size: 8 })]),
+      value: 1000n,
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'withdrawal' });
+  });
+
+  test('consolidate — two different pubkeys to the EIP-7251 predeploy', async () => {
+    const verdict = await classify({
+      to: CONSOLIDATION_REQUEST_PREDEPLOY,
+      data: concat([pubkeyA, pubkeyB]),
+      value: 1000n,
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'consolidate' });
+  });
+
+  test('enable-compounding — the same pubkey consolidated onto itself', async () => {
+    const verdict = await classify({
+      to: CONSOLIDATION_REQUEST_PREDEPLOY,
+      data: concat([pubkeyA, pubkeyA]),
+      value: 1000n,
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'enable-compounding' });
+  });
+
+  test('stake — a beacon deposit carrying 32 ETH', async () => {
+    const verdict = await classify({
+      to: ETH_BEACON_DEPOSIT_CONTRACT_ADDRESS,
+      data: call(
+        'function deposit(bytes pubkey, bytes withdrawal_credentials, bytes signature, bytes32 deposit_data_root) external payable',
+        'deposit',
+        [pubkeyA, `0x${'01'.repeat(32)}`, `0x${'cc'.repeat(96)}`, `0x${'dd'.repeat(32)}`],
+      ),
+      value: 32000000000000000000n,
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'stake' });
+  });
+
+  test('multi-claim — multiClaim on the exit queue helper', async () => {
+    const verdict = await classify({
+      to: EXIT_QUEUE_HELPER_ADDRESS,
+      data: call(
+        'function multiClaim(address[] exitQueues, uint256[][] ticketIds, uint32[][] casksIds) external',
+        'multiClaim',
+        [['0x1111111111111111111111111111111111111111'], [[1n]], [[0]]],
+      ),
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'multi-claim' });
+  });
+
+  test('buy-voucher — Polygon delegation', async () => {
+    const verdict = await classify({
+      to: MATIC_STAKE_MANAGER_CONTRACT_ADDRESS,
+      data: call(
+        'function buyVoucherPOL(uint256 _amount, uint256 _minSharesToMint) returns (uint256)',
+        'buyVoucherPOL',
+        [1000000000000000000n, 0n],
+      ),
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'buy-voucher' });
+  });
+
+  test('the testnets Kiln uses are recognized too', async () => {
+    for (const chainId of [11155111, 560048]) {
+      const verdict = await classify({
+        chainId,
+        to: ETH_EXIT_CONTRACT_ADDRESS,
+        data: call('function requestExit(bytes[] validators_) external', 'requestExit', [[pubkeyA]]),
+      });
+
+      expect(verdict).toMatchObject({ status: 'recognized', operation: 'exit-request' });
+    }
+  });
+});
+
+describe('Non-Kiln Ethereum transactions are rejected', () => {
+  test('SEC-358: a Kiln-shaped call on Base is rejected on the chain id alone', async () => {
+    const verdict = await classify({
+      chainId: 8453,
+      to: ETH_EXIT_CONTRACT_ADDRESS,
+      data: call('function requestExit(bytes[] validators_) external', 'requestExit', [[pubkeyA]]),
+    });
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('chain 8453') });
+  });
+
+  test('EigenLayer delegateTo — dropped from Kiln Connect in API v1.10', async () => {
+    const verdict = await classify({
+      to: EIGENLAYER_DELEGATION_MANAGER_ADDRESS,
+      data: call(
+        'function undelegate(address staker) external returns (bytes32[] memory withdrawalRoots)',
+        'undelegate',
+        ['0x1111111111111111111111111111111111111111'],
+      ),
+    });
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('undelegate()') });
+  });
+
+  test('a vault administration call no customer route crafts', async () => {
+    const verdict = await classify({
+      to: '0x4444444444444444444444444444444444444444',
+      data: call('function updateNewTotalAssets(uint256 newTotalAssets) external', 'updateNewTotalAssets', [1n]),
+    });
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('updateNewTotalAssets()') });
+  });
+
+  test('a plain ETH transfer', async () => {
+    const verdict = await classify({ to: '0x5555555555555555555555555555555555555555', value: 10n ** 18n });
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('plain ETH transfer') });
+  });
+
+  test('an ERC-20 transfer', async () => {
+    const verdict = await classify({
+      to: '0x6666666666666666666666666666666666666666',
+      data: call('function transfer(address to, uint256 amount) returns (bool)', 'transfer', [
+        '0x1111111111111111111111111111111111111111',
+        1n,
+      ]),
+    });
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('transfer()') });
+  });
+
+  test('a malformed payload to the withdrawal predeploy', async () => {
+    const verdict = await classify({
+      to: WITHDRAWAL_REQUEST_PREDEPLOY,
+      data: `0x${'ab'.repeat(20)}`,
+      value: 1000n,
+    });
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('20 bytes') });
+  });
+});
+
+describe('The one call minitel cannot decide', () => {
+  test('approve is unverified, because the spender is not knowable here', async () => {
+    const verdict = await classify({
+      to: '0x7777777777777777777777777777777777777777',
+      data: call('function approve(address spender, uint256 amount) returns (bool)', 'approve', [
+        '0x2222222222222222222222222222222222222222',
+        2n ** 256n - 1n,
+      ]),
+    });
+
+    expect(verdict.status).toBe('unverified');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('spender') });
+  });
+});

--- a/apps/ethereum/src/kiln-operations.test.ts
+++ b/apps/ethereum/src/kiln-operations.test.ts
@@ -10,10 +10,7 @@ import {
 import { classifyEthereumTransaction } from '@/kiln-operations';
 import { parseEthTx } from '@/parser';
 
-/**
- * The calls below mirror how Kiln's transaction-crafting API builds each operation, so a change on
- * either side shows up here rather than in production.
- */
+/** These mirror how Kiln crafts each operation, so a drift on either side shows up here. */
 
 const WITHDRAWAL_REQUEST_PREDEPLOY = '0x00000961Ef480Eb55e80D19ad83579A64c007002' as const;
 const CONSOLIDATION_REQUEST_PREDEPLOY = '0x0000BBdDc7CE488642fb579F8B00f3a590007251' as const;

--- a/apps/ethereum/src/kiln-operations.test.ts
+++ b/apps/ethereum/src/kiln-operations.test.ts
@@ -155,7 +155,7 @@ describe('Kiln Ethereum operations are recognized', () => {
 });
 
 describe('Non-Kiln Ethereum transactions are rejected', () => {
-  test('a Kiln-shaped call on Base is rejected on the chain id alone', async () => {
+  test('an exit request replayed on Base is rejected — the ABI is never applied there', async () => {
     const verdict = await classify({
       chainId: 8453,
       to: ETH_EXIT_CONTRACT_ADDRESS,
@@ -163,7 +163,34 @@ describe('Non-Kiln Ethereum transactions are rejected', () => {
     });
 
     expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('could not match') });
+  });
+
+  test('an exit request to the predeploy on Base names the chain, since predeploys decode anywhere', async () => {
+    const verdict = await classify({
+      chainId: 8453,
+      to: WITHDRAWAL_REQUEST_PREDEPLOY,
+      data: concat([pubkeyA, numberToHex(0, { size: 8 })]),
+      value: 1000n,
+    });
+
+    expect(verdict.status).toBe('unrecognized');
     expect(verdict).toMatchObject({ reason: expect.stringContaining('chain 8453') });
+  });
+
+  test('a vault withdrawal on a chain Kiln has no vaults on', async () => {
+    const verdict = await classify({
+      chainId: 250,
+      to: '0x8888888888888888888888888888888888888888',
+      data: call('function redeem(uint256 shares, address receiver, address owner) returns (uint256)', 'redeem', [
+        1n,
+        '0x1111111111111111111111111111111111111111',
+        '0x1111111111111111111111111111111111111111',
+      ]),
+    });
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('chain 250') });
   });
 
   test('EigenLayer delegateTo — dropped from Kiln Connect in API v1.10', async () => {
@@ -222,9 +249,45 @@ describe('Non-Kiln Ethereum transactions are rejected', () => {
   });
 });
 
-describe('The one call minitel cannot decide', () => {
-  test('approve is unverified, because the spender is not knowable here', async () => {
+describe('Vault operations are multi-chain, unlike staking', () => {
+  test.each([
+    ['Base', 8453],
+    ['Arbitrum', 42161],
+    ['Optimism', 10],
+    ['Polygon', 137],
+    ['Celo', 42220],
+  ])('an ERC-4626 vault deposit on %s is recognized', async (_name, chainId) => {
     const verdict = await classify({
+      chainId,
+      to: '0x8888888888888888888888888888888888888888',
+      data: call('function deposit(uint256 assets, address receiver) returns (uint256)', 'deposit', [
+        1000000n,
+        '0x1111111111111111111111111111111111111111',
+      ]),
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'defi-deposit' });
+  });
+
+  test('a vault withdrawal on Base is recognized', async () => {
+    const verdict = await classify({
+      chainId: 8453,
+      to: '0x8888888888888888888888888888888888888888',
+      data: call('function withdraw(uint256 assets, address receiver, address owner) returns (uint256)', 'withdraw', [
+        1000000n,
+        '0x1111111111111111111111111111111111111111',
+        '0x1111111111111111111111111111111111111111',
+      ]),
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'defi-withdraw' });
+  });
+});
+
+describe('The one call minitel cannot decide', () => {
+  test('approve on Base is unverified, because the spender is not knowable here', async () => {
+    const verdict = await classify({
+      chainId: 8453,
       to: '0x7777777777777777777777777777777777777777',
       data: call('function approve(address spender, uint256 amount) returns (bool)', 'approve', [
         '0x2222222222222222222222222222222222222222',

--- a/apps/ethereum/src/kiln-operations.test.ts
+++ b/apps/ethereum/src/kiln-operations.test.ts
@@ -11,9 +11,8 @@ import { classifyEthereumTransaction } from '@/kiln-operations';
 import { parseEthTx } from '@/parser';
 
 /**
- * The calls below mirror how services/sof/tx builds each operation (EthService, PolService,
- * MaticService, DefiService), so a change on either side shows up here rather than in
- * production.
+ * The calls below mirror how Kiln's transaction-crafting API builds each operation, so a change on
+ * either side shows up here rather than in production.
  */
 
 const WITHDRAWAL_REQUEST_PREDEPLOY = '0x00000961Ef480Eb55e80D19ad83579A64c007002' as const;
@@ -156,7 +155,7 @@ describe('Kiln Ethereum operations are recognized', () => {
 });
 
 describe('Non-Kiln Ethereum transactions are rejected', () => {
-  test('SEC-358: a Kiln-shaped call on Base is rejected on the chain id alone', async () => {
+  test('a Kiln-shaped call on Base is rejected on the chain id alone', async () => {
     const verdict = await classify({
       chainId: 8453,
       to: ETH_EXIT_CONTRACT_ADDRESS,

--- a/apps/ethereum/src/kiln-operations.ts
+++ b/apps/ethereum/src/kiln-operations.ts
@@ -1,0 +1,167 @@
+import { recognized, type TransactionVerdict, unrecognized, unverified } from '@protocols/shared';
+import { isAddressEqual, size, slice } from 'viem';
+import { ETHEREUM_CHAIN_IDS } from '@/constant';
+import type { AugmentedTransaction } from '@/types';
+
+/**
+ * The Ethereum operations Kiln crafts, and the calls each one makes.
+ *
+ * Source of truth is the crafting service (services/sof/tx: EthService, PolService, MaticService
+ * and DefiService) and the public Kiln Connect spec, which expose the same set across
+ * `/eth/transaction/*`, `/pol/transaction/*`, `/matic/transaction/*` and `/defi/transaction/*`.
+ *
+ * Most of them are ordinary contract calls, so the function the transaction decodes to is what
+ * identifies the operation. Matching on the function rather than the contract address is
+ * deliberate and matches the other chains: the deposit contract, the exit-queue helper and the
+ * per-customer onchain-v2 vaults all live in Kiln's configuration and change without minitel
+ * knowing. The address→ABI map is still what makes the decode possible, and SEC-358 gates that
+ * map on chain id, so a call only reaches this classifier already labelled by a contract Kiln
+ * actually deploys on a chain Kiln actually uses.
+ *
+ * Two operations have no ABI at all: validator exits and consolidations are raw payloads sent
+ * to the execution-layer predeploys from EIP-7002 and EIP-7251. Those are Ethereum protocol
+ * constants rather than Kiln configuration, so matching them on address plus payload shape is
+ * safe from going stale.
+ */
+
+/** EIP-7002 withdrawal/exit request predeploy: 48-byte pubkey followed by an 8-byte amount. */
+const WITHDRAWAL_REQUEST_PREDEPLOY = '0x00000961Ef480Eb55e80D19ad83579A64c007002' as const;
+const WITHDRAWAL_REQUEST_SIZE = 56;
+
+/** EIP-7251 consolidation request predeploy: a 48-byte source and a 48-byte target pubkey. */
+const CONSOLIDATION_REQUEST_PREDEPLOY = '0x0000BBdDc7CE488642fb579F8B00f3a590007251' as const;
+const CONSOLIDATION_REQUEST_SIZE = 96;
+
+const PUBKEY_SIZE = 48;
+
+/**
+ * Decoded function name → the Kiln operation that produces it.
+ *
+ * EigenLayer's calls are deliberately absent even though the ABIs to decode them are still
+ * bundled: Kiln Connect removed EigenLayer support in API v1.10, along with Kava and ZetaChain,
+ * so `delegateTo`, `undelegate`, `createPod` and `completeQueuedWithdrawals` are no longer
+ * operations Kiln produces.
+ *
+ * The async-vault operator functions are absent for the same fail-closed reason. `settleDeposit`,
+ * `updateNewTotalAssets`, `close` and friends are vault-administration calls that no customer
+ * route crafts, so a customer being asked to sign one is exactly the case worth flagging.
+ */
+const OPERATION_BY_FUNCTION: Record<string, string> = {
+  // Native staking — /eth/transaction/{stake,deposit}
+  deposit: 'stake',
+  batchDeposit: 'stake',
+  batchDepositCustom: 'stake',
+  bigBatchDeposit: 'stake',
+  bigBatchDepositCustom: 'stake',
+  // Pooled (onchain v2) staking
+  stake: 'stake',
+  requestExit: 'exit-request',
+  requestValidatorsExit: 'exit-request',
+  multiClaim: 'multi-claim',
+  // DeFi vaults — /defi/transaction/withdraw crafts redeem when withdrawing everything
+  withdraw: 'defi-withdraw',
+  redeem: 'defi-withdraw',
+  // Polygon — /pol/transaction/* and /matic/transaction/*
+  buyVoucher: 'buy-voucher',
+  buyVoucherPOL: 'buy-voucher',
+  sellVoucher: 'sell-voucher',
+  sellVoucherPOL: 'sell-voucher',
+  withdrawRewards: 'withdraw-rewards',
+  withdrawRewardsPOL: 'withdraw-rewards',
+  restake: 'restake-rewards',
+  restakePOL: 'restake-rewards',
+  unstakeClaimTokens: 'unstake-claim-tokens',
+};
+
+/** `deposit` is shared between the beacon deposit contract and the ERC-4626 vault flow. */
+const isVaultDeposit = (tx: AugmentedTransaction): boolean => (tx.value ?? 0n) === 0n;
+
+const chainIdOf = (tx: AugmentedTransaction): number | null => (tx.chainId === undefined ? null : Number(tx.chainId));
+
+/**
+ * The raw predeploy payloads. An exit is a withdrawal of zero — the same request with the
+ * amount field cleared — and enabling compounding is a consolidation of a validator onto
+ * itself, so each pair is told apart by reading the payload rather than by a separate address.
+ */
+const classifyPredeployCall = (to: `0x${string}`, data: `0x${string}`): TransactionVerdict | null => {
+  if (isAddressEqual(to, WITHDRAWAL_REQUEST_PREDEPLOY)) {
+    if (size(data) !== WITHDRAWAL_REQUEST_SIZE) {
+      return unrecognized(
+        `This transaction sends ${size(data)} bytes to the withdrawal request predeploy. A Kiln exit or withdrawal request is ${WITHDRAWAL_REQUEST_SIZE} bytes: a validator public key and an amount.`,
+      );
+    }
+    const amount = BigInt(slice(data, PUBKEY_SIZE));
+    return recognized(amount === 0n ? 'exit-request' : 'withdrawal');
+  }
+
+  if (isAddressEqual(to, CONSOLIDATION_REQUEST_PREDEPLOY)) {
+    if (size(data) !== CONSOLIDATION_REQUEST_SIZE) {
+      return unrecognized(
+        `This transaction sends ${size(data)} bytes to the consolidation request predeploy. A Kiln consolidation is ${CONSOLIDATION_REQUEST_SIZE} bytes: a source and a target validator public key.`,
+      );
+    }
+    const source = slice(data, 0, PUBKEY_SIZE);
+    const target = slice(data, PUBKEY_SIZE);
+    return recognized(source === target ? 'enable-compounding' : 'consolidate');
+  }
+
+  return null;
+};
+
+export const classifyEthereumTransaction = (tx: AugmentedTransaction): TransactionVerdict => {
+  const chainId = chainIdOf(tx);
+
+  // SEC-358: the same contract address means something different on every other EVM chain, so
+  // the chain is part of the operation's identity, not a detail below it.
+  if (chainId === null) {
+    return unrecognized(
+      'This transaction declares no chain id, so it cannot be tied to the Ethereum network Kiln operates on.',
+    );
+  }
+  if (!ETHEREUM_CHAIN_IDS.includes(chainId)) {
+    return unrecognized(
+      `This transaction is for chain ${chainId}. Kiln crafts Ethereum operations on mainnet, sepolia and hoodi only.`,
+    );
+  }
+
+  if (!tx.to) {
+    return unrecognized('This transaction deploys a contract rather than calling one.');
+  }
+
+  if (tx.data && tx.data !== '0x') {
+    const predeploy = classifyPredeployCall(tx.to, tx.data);
+    if (predeploy) return predeploy;
+  }
+
+  if (!('inputData' in tx) || !tx.inputData) {
+    return unrecognized(
+      (tx.value ?? 0n) > 0n && (!tx.data || tx.data === '0x')
+        ? 'This transaction is a plain ETH transfer. Kiln staking operations are all contract calls.'
+        : 'This transaction calls a contract minitel could not match to any Kiln operation.',
+    );
+  }
+
+  const { functionName } = tx.inputData;
+
+  // Kiln's DeFi flow crafts an approval, but its whole safety rests on the spender being a Kiln
+  // vault — an address that lives in Kiln's configuration and is not knowable here. Calling it
+  // recognized would rubber-stamp an approval to a drainer; calling it unrecognized would
+  // reject a real operation. It is genuinely the one case minitel cannot answer.
+  if (functionName === 'approve') {
+    return unverified(
+      'This is the shape of the token approval Kiln crafts before a vault deposit, but minitel cannot confirm the spender is a Kiln vault. Check the spender address below against the vault you are depositing into.',
+    );
+  }
+
+  const operation = OPERATION_BY_FUNCTION[functionName];
+
+  if (!operation) {
+    return unrecognized(`This transaction calls ${functionName}(), which is not a function Kiln operations use.`);
+  }
+
+  if (operation === 'stake' && functionName === 'deposit' && isVaultDeposit(tx)) {
+    return recognized('defi-deposit');
+  }
+
+  return recognized(operation);
+};

--- a/apps/ethereum/src/kiln-operations.ts
+++ b/apps/ethereum/src/kiln-operations.ts
@@ -4,23 +4,10 @@ import { DEFI_CHAIN_IDS, ETHEREUM_CHAIN_IDS } from '@/constant';
 import type { AugmentedTransaction } from '@/types';
 
 /**
- * The Ethereum operations Kiln crafts, and the calls each one makes.
- *
- * Source of truth is Kiln's transaction-crafting API and the public Kiln Connect spec, which expose the same set across
- * `/eth/transaction/*`, `/pol/transaction/*`, `/matic/transaction/*` and `/defi/transaction/*`.
- *
- * Most of them are ordinary contract calls, so the function the transaction decodes to is what
- * identifies the operation. Matching on the function rather than the contract address is
- * deliberate and matches the other chains: the deposit contract, the exit-queue helper and the
- * per-customer onchain-v2 vaults all live in Kiln's configuration and change without minitel
- * knowing. The address→ABI map is still what makes the decode possible, and chain-id gating gates that
- * map on chain id, so a call only reaches this classifier already labelled by a contract Kiln
- * actually deploys on a chain Kiln actually uses.
- *
- * Two operations have no ABI at all: validator exits and consolidations are raw payloads sent
- * to the execution-layer predeploys from EIP-7002 and EIP-7251. Those are Ethereum protocol
- * constants rather than Kiln configuration, so matching them on address plus payload shape is
- * safe from going stale.
+ * Kiln's Ethereum operations are mostly ordinary contract calls, so the decoded function
+ * identifies them — not the contract address, which is Kiln configuration. Validator exits and
+ * consolidations have no ABI at all: they are raw payloads to the EIP-7002 and EIP-7251
+ * predeploys, which are protocol constants and so safe to match on address plus shape.
  */
 
 /** EIP-7002 withdrawal/exit request predeploy: 48-byte pubkey followed by an 8-byte amount. */
@@ -34,16 +21,8 @@ const CONSOLIDATION_REQUEST_SIZE = 96;
 const PUBKEY_SIZE = 48;
 
 /**
- * Decoded function name → the Kiln operation that produces it.
- *
- * EigenLayer's calls are deliberately absent even though the ABIs to decode them are still
- * bundled: Kiln Connect removed EigenLayer support in API v1.10, along with Kava and ZetaChain,
- * so `delegateTo`, `undelegate`, `createPod` and `completeQueuedWithdrawals` are no longer
- * operations Kiln produces.
- *
- * The async-vault operator functions are absent for the same fail-closed reason. `settleDeposit`,
- * `updateNewTotalAssets`, `close` and friends are vault-administration calls that no customer
- * route crafts, so a customer being asked to sign one is exactly the case worth flagging.
+ * Two absences are deliberate: EigenLayer's calls, dropped from Kiln Connect in API v1.10, and
+ * the async-vault operator functions, which no customer route crafts.
  */
 type Scope = 'ethereum' | 'defi';
 
@@ -54,8 +33,7 @@ const SCOPES: Record<Scope, { chainIds: readonly number[]; where: string }> = {
 };
 
 const OPERATION_BY_FUNCTION: Record<string, { operation: string; scope: Scope }> = {
-  // Native staking. The beacon deposit is payable and always carries ETH, which is what
-  // separates it from the ERC-4626 vault deposit that shares the name.
+  // The beacon deposit is payable, which separates it from the vault deposit of the same name.
   deposit: { operation: 'stake', scope: 'ethereum' },
   batchDeposit: { operation: 'stake', scope: 'ethereum' },
   batchDepositCustom: { operation: 'stake', scope: 'ethereum' },
@@ -86,11 +64,7 @@ const isVaultDeposit = (tx: AugmentedTransaction): boolean => (tx.value ?? 0n) =
 
 const chainIdOf = (tx: AugmentedTransaction): number | null => (tx.chainId === undefined ? null : Number(tx.chainId));
 
-/**
- * The raw predeploy payloads. An exit is a withdrawal of zero — the same request with the
- * amount field cleared — and enabling compounding is a consolidation of a validator onto
- * itself, so each pair is told apart by reading the payload rather than by a separate address.
- */
+/** An exit is a withdrawal of zero; enabling compounding is a consolidation onto itself. */
 const classifyPredeployCall = (to: `0x${string}`, data: `0x${string}`): TransactionVerdict | null => {
   if (isAddressEqual(to, WITHDRAWAL_REQUEST_PREDEPLOY)) {
     if (size(data) !== WITHDRAWAL_REQUEST_SIZE) {
@@ -139,8 +113,7 @@ export const classifyEthereumTransaction = (tx: AugmentedTransaction): Transacti
 
   if (tx.data && tx.data !== '0x') {
     const predeploy = classifyPredeployCall(tx.to, tx.data);
-    // The predeploys exist on every chain that has adopted the EIPs, but a Kiln validator
-    // request is only ever for the Ethereum network Kiln runs validators on.
+    // The predeploys exist wherever the EIPs are adopted, but Kiln's validators are on Ethereum.
     if (predeploy) {
       if (predeploy.status !== 'recognized') return predeploy;
       return onSupportedChain(predeploy.operation, 'ethereum');
@@ -157,10 +130,8 @@ export const classifyEthereumTransaction = (tx: AugmentedTransaction): Transacti
 
   const { functionName } = tx.inputData;
 
-  // Kiln's vault flow crafts an approval, but its whole safety rests on the spender being a Kiln
-  // vault — an address that lives in Kiln's configuration and is not knowable here. Calling it
-  // recognized would rubber-stamp an approval to a drainer; calling it unrecognized would
-  // reject a real operation. It is genuinely the one case minitel cannot answer.
+  // The approval's safety rests entirely on the spender being a Kiln vault, which is not
+  // knowable here — green would rubber-stamp a drainer, red would reject a real operation.
   if (functionName === 'approve') {
     if (!DEFI_CHAIN_IDS.includes(chainId)) {
       return unrecognized(
@@ -178,8 +149,7 @@ export const classifyEthereumTransaction = (tx: AugmentedTransaction): Transacti
     return unrecognized(`This transaction calls ${functionName}(), which is not a function Kiln operations use.`);
   }
 
-  // `deposit` is shared: the beacon deposit contract is payable and always carries ETH, while
-  // an ERC-4626 vault deposit moves tokens and carries none.
+  // `deposit` is shared: the beacon contract carries ETH, an ERC-4626 vault deposit does not.
   if (functionName === 'deposit' && isVaultDeposit(tx)) {
     return onSupportedChain('defi-deposit', 'defi');
   }

--- a/apps/ethereum/src/kiln-operations.ts
+++ b/apps/ethereum/src/kiln-operations.ts
@@ -1,6 +1,6 @@
 import { recognized, type TransactionVerdict, unrecognized, unverified } from '@protocols/shared';
 import { isAddressEqual, size, slice } from 'viem';
-import { ETHEREUM_CHAIN_IDS } from '@/constant';
+import { DEFI_CHAIN_IDS, ETHEREUM_CHAIN_IDS } from '@/constant';
 import type { AugmentedTransaction } from '@/types';
 
 /**
@@ -45,31 +45,40 @@ const PUBKEY_SIZE = 48;
  * `updateNewTotalAssets`, `close` and friends are vault-administration calls that no customer
  * route crafts, so a customer being asked to sign one is exactly the case worth flagging.
  */
-const OPERATION_BY_FUNCTION: Record<string, string> = {
-  // Native staking — /eth/transaction/{stake,deposit}
-  deposit: 'stake',
-  batchDeposit: 'stake',
-  batchDepositCustom: 'stake',
-  bigBatchDeposit: 'stake',
-  bigBatchDepositCustom: 'stake',
-  // Pooled (onchain v2) staking
-  stake: 'stake',
-  requestExit: 'exit-request',
-  requestValidatorsExit: 'exit-request',
-  multiClaim: 'multi-claim',
-  // DeFi vaults — /defi/transaction/withdraw crafts redeem when withdrawing everything
-  withdraw: 'defi-withdraw',
-  redeem: 'defi-withdraw',
-  // Polygon — /pol/transaction/* and /matic/transaction/*
-  buyVoucher: 'buy-voucher',
-  buyVoucherPOL: 'buy-voucher',
-  sellVoucher: 'sell-voucher',
-  sellVoucherPOL: 'sell-voucher',
-  withdrawRewards: 'withdraw-rewards',
-  withdrawRewardsPOL: 'withdraw-rewards',
-  restake: 'restake-rewards',
-  restakePOL: 'restake-rewards',
-  unstakeClaimTokens: 'unstake-claim-tokens',
+type Scope = 'ethereum' | 'defi';
+
+/** Which chains an operation exists on, and how to say so when it does not. */
+const SCOPES: Record<Scope, { chainIds: readonly number[]; where: string }> = {
+  ethereum: { chainIds: ETHEREUM_CHAIN_IDS, where: 'mainnet, sepolia and hoodi' },
+  defi: { chainIds: DEFI_CHAIN_IDS, where: 'Ethereum, Optimism, BNB Chain, Polygon, Base, Arbitrum and Celo' },
+};
+
+const OPERATION_BY_FUNCTION: Record<string, { operation: string; scope: Scope }> = {
+  // Native staking. The beacon deposit is payable and always carries ETH, which is what
+  // separates it from the ERC-4626 vault deposit that shares the name.
+  deposit: { operation: 'stake', scope: 'ethereum' },
+  batchDeposit: { operation: 'stake', scope: 'ethereum' },
+  batchDepositCustom: { operation: 'stake', scope: 'ethereum' },
+  bigBatchDeposit: { operation: 'stake', scope: 'ethereum' },
+  bigBatchDepositCustom: { operation: 'stake', scope: 'ethereum' },
+  // Pooled staking
+  stake: { operation: 'stake', scope: 'ethereum' },
+  requestExit: { operation: 'exit-request', scope: 'ethereum' },
+  requestValidatorsExit: { operation: 'exit-request', scope: 'ethereum' },
+  multiClaim: { operation: 'multi-claim', scope: 'ethereum' },
+  // DeFi vaults — withdrawing everything is crafted as redeem
+  withdraw: { operation: 'defi-withdraw', scope: 'defi' },
+  redeem: { operation: 'defi-withdraw', scope: 'defi' },
+  // Polygon staking
+  buyVoucher: { operation: 'buy-voucher', scope: 'ethereum' },
+  buyVoucherPOL: { operation: 'buy-voucher', scope: 'ethereum' },
+  sellVoucher: { operation: 'sell-voucher', scope: 'ethereum' },
+  sellVoucherPOL: { operation: 'sell-voucher', scope: 'ethereum' },
+  withdrawRewards: { operation: 'withdraw-rewards', scope: 'ethereum' },
+  withdrawRewardsPOL: { operation: 'withdraw-rewards', scope: 'ethereum' },
+  restake: { operation: 'restake-rewards', scope: 'ethereum' },
+  restakePOL: { operation: 'restake-rewards', scope: 'ethereum' },
+  unstakeClaimTokens: { operation: 'unstake-claim-tokens', scope: 'ethereum' },
 };
 
 /** `deposit` is shared between the beacon deposit contract and the ERC-4626 vault flow. */
@@ -110,57 +119,70 @@ const classifyPredeployCall = (to: `0x${string}`, data: `0x${string}`): Transact
 export const classifyEthereumTransaction = (tx: AugmentedTransaction): TransactionVerdict => {
   const chainId = chainIdOf(tx);
 
-  // the same contract address means something different on every other EVM chain, so
-  // the chain is part of the operation's identity, not a detail below it.
   if (chainId === null) {
-    return unrecognized(
-      'This transaction declares no chain id, so it cannot be tied to the Ethereum network Kiln operates on.',
-    );
-  }
-  if (!ETHEREUM_CHAIN_IDS.includes(chainId)) {
-    return unrecognized(
-      `This transaction is for chain ${chainId}. Kiln crafts Ethereum operations on mainnet, sepolia and hoodi only.`,
-    );
+    return unrecognized('This transaction declares no chain id, so it cannot be tied to a network Kiln operates on.');
   }
 
   if (!tx.to) {
     return unrecognized('This transaction deploys a contract rather than calling one.');
   }
 
+  /** An operation only counts on a chain that actually offers it. */
+  const onSupportedChain = (operation: string, scope: Scope): TransactionVerdict => {
+    const { chainIds, where } = SCOPES[scope];
+    return chainIds.includes(chainId)
+      ? recognized(operation)
+      : unrecognized(
+          `This transaction is for chain ${chainId}. Kiln crafts ${scope === 'defi' ? 'vault' : 'staking'} operations on ${where}.`,
+        );
+  };
+
   if (tx.data && tx.data !== '0x') {
     const predeploy = classifyPredeployCall(tx.to, tx.data);
-    if (predeploy) return predeploy;
+    // The predeploys exist on every chain that has adopted the EIPs, but a Kiln validator
+    // request is only ever for the Ethereum network Kiln runs validators on.
+    if (predeploy) {
+      if (predeploy.status !== 'recognized') return predeploy;
+      return onSupportedChain(predeploy.operation, 'ethereum');
+    }
   }
 
   if (!('inputData' in tx) || !tx.inputData) {
     return unrecognized(
       (tx.value ?? 0n) > 0n && (!tx.data || tx.data === '0x')
-        ? 'This transaction is a plain ETH transfer. Kiln staking operations are all contract calls.'
+        ? 'This transaction is a plain ETH transfer. Kiln operations are all contract calls.'
         : 'This transaction calls a contract minitel could not match to any Kiln operation.',
     );
   }
 
   const { functionName } = tx.inputData;
 
-  // Kiln's DeFi flow crafts an approval, but its whole safety rests on the spender being a Kiln
+  // Kiln's vault flow crafts an approval, but its whole safety rests on the spender being a Kiln
   // vault — an address that lives in Kiln's configuration and is not knowable here. Calling it
   // recognized would rubber-stamp an approval to a drainer; calling it unrecognized would
   // reject a real operation. It is genuinely the one case minitel cannot answer.
   if (functionName === 'approve') {
+    if (!DEFI_CHAIN_IDS.includes(chainId)) {
+      return unrecognized(
+        `This transaction is for chain ${chainId}. Kiln crafts vault operations on ${SCOPES.defi.where}.`,
+      );
+    }
     return unverified(
       'This is the shape of the token approval Kiln crafts before a vault deposit, but minitel cannot confirm the spender is a Kiln vault. Check the spender address below against the vault you are depositing into.',
     );
   }
 
-  const operation = OPERATION_BY_FUNCTION[functionName];
+  const match = OPERATION_BY_FUNCTION[functionName];
 
-  if (!operation) {
+  if (!match) {
     return unrecognized(`This transaction calls ${functionName}(), which is not a function Kiln operations use.`);
   }
 
-  if (operation === 'stake' && functionName === 'deposit' && isVaultDeposit(tx)) {
-    return recognized('defi-deposit');
+  // `deposit` is shared: the beacon deposit contract is payable and always carries ETH, while
+  // an ERC-4626 vault deposit moves tokens and carries none.
+  if (functionName === 'deposit' && isVaultDeposit(tx)) {
+    return onSupportedChain('defi-deposit', 'defi');
   }
 
-  return recognized(operation);
+  return onSupportedChain(match.operation, match.scope);
 };

--- a/apps/ethereum/src/kiln-operations.ts
+++ b/apps/ethereum/src/kiln-operations.ts
@@ -6,15 +6,14 @@ import type { AugmentedTransaction } from '@/types';
 /**
  * The Ethereum operations Kiln crafts, and the calls each one makes.
  *
- * Source of truth is the crafting service (services/sof/tx: EthService, PolService, MaticService
- * and DefiService) and the public Kiln Connect spec, which expose the same set across
+ * Source of truth is Kiln's transaction-crafting API and the public Kiln Connect spec, which expose the same set across
  * `/eth/transaction/*`, `/pol/transaction/*`, `/matic/transaction/*` and `/defi/transaction/*`.
  *
  * Most of them are ordinary contract calls, so the function the transaction decodes to is what
  * identifies the operation. Matching on the function rather than the contract address is
  * deliberate and matches the other chains: the deposit contract, the exit-queue helper and the
  * per-customer onchain-v2 vaults all live in Kiln's configuration and change without minitel
- * knowing. The address→ABI map is still what makes the decode possible, and SEC-358 gates that
+ * knowing. The address→ABI map is still what makes the decode possible, and chain-id gating gates that
  * map on chain id, so a call only reaches this classifier already labelled by a contract Kiln
  * actually deploys on a chain Kiln actually uses.
  *
@@ -111,7 +110,7 @@ const classifyPredeployCall = (to: `0x${string}`, data: `0x${string}`): Transact
 export const classifyEthereumTransaction = (tx: AugmentedTransaction): TransactionVerdict => {
   const chainId = chainIdOf(tx);
 
-  // SEC-358: the same contract address means something different on every other EVM chain, so
+  // the same contract address means something different on every other EVM chain, so
   // the chain is part of the operation's identity, not a detail below it.
   if (chainId === null) {
     return unrecognized(

--- a/apps/ethereum/src/parser.test.ts
+++ b/apps/ethereum/src/parser.test.ts
@@ -4,10 +4,8 @@ import { EIGENLAYER_DELEGATION_MANAGER_ADDRESS, ETH_EXIT_CONTRACT_ADDRESS } from
 import { parseEthTx } from '@/parser';
 
 /**
- * the hardcoded address→ABI map is keyed by destination address alone, so a
- * transaction on any other EVM chain that happens to target one of those addresses used to
- * inherit an Ethereum protocol label. The address may be empty, or attacker-controlled, on the
- * chain actually being signed for.
+ * The address→ABI map is keyed by destination address alone, so a transaction on another EVM
+ * chain targeting one of those addresses used to inherit an Ethereum protocol label.
  */
 
 const DELEGATION_MANAGER_ABI = parseAbi([

--- a/apps/ethereum/src/parser.test.ts
+++ b/apps/ethereum/src/parser.test.ts
@@ -4,7 +4,7 @@ import { EIGENLAYER_DELEGATION_MANAGER_ADDRESS, ETH_EXIT_CONTRACT_ADDRESS } from
 import { parseEthTx } from '@/parser';
 
 /**
- * SEC-358: the hardcoded address→ABI map is keyed by destination address alone, so a
+ * the hardcoded address→ABI map is keyed by destination address alone, so a
  * transaction on any other EVM chain that happens to target one of those addresses used to
  * inherit an Ethereum protocol label. The address may be empty, or attacker-controlled, on the
  * chain actually being signed for.

--- a/apps/ethereum/src/parser.test.ts
+++ b/apps/ethereum/src/parser.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+import { encodeFunctionData, parseAbi } from 'viem';
+import { EIGENLAYER_DELEGATION_MANAGER_ADDRESS, ETH_EXIT_CONTRACT_ADDRESS } from '@/constant';
+import { parseEthTx } from '@/parser';
+
+/**
+ * SEC-358: the hardcoded address→ABI map is keyed by destination address alone, so a
+ * transaction on any other EVM chain that happens to target one of those addresses used to
+ * inherit an Ethereum protocol label. The address may be empty, or attacker-controlled, on the
+ * chain actually being signed for.
+ */
+
+const DELEGATION_MANAGER_ABI = parseAbi([
+  'struct SignatureWithExpiry { bytes signature; uint256 expiry; }',
+  'function delegateTo(address operator, SignatureWithExpiry approverSignatureAndExpiry, bytes32 approverSalt) external',
+]);
+
+const delegateToCalldata = encodeFunctionData({
+  abi: DELEGATION_MANAGER_ABI,
+  functionName: 'delegateTo',
+  args: ['0x1111111111111111111111111111111111111111', { signature: '0x', expiry: 0n }, `0x${'00'.repeat(32)}`],
+});
+
+/** A transaction the way the manual-input form builds it, as JSON. */
+const tx = ({ to, data, chainId }: { to: string; data: string; chainId?: string }) =>
+  JSON.stringify({ to, data, ...(chainId === undefined ? {} : { chainId }), value: '0', nonce: '0' });
+
+describe('protocol ABIs are only applied on Ethereum chains', () => {
+  test('delegateTo on mainnet decodes as the EigenLayer action', async () => {
+    const parsed = await parseEthTx(
+      tx({ to: EIGENLAYER_DELEGATION_MANAGER_ADDRESS, data: delegateToCalldata, chainId: '1' }),
+    );
+
+    expect(parsed).toHaveProperty('inputData');
+    expect(parsed).toMatchObject({ inputData: { functionName: 'delegateTo' } });
+  });
+
+  test.each([
+    ['Base', '8453'],
+    ['Arbitrum', '42161'],
+    ['Optimism', '10'],
+  ])('the same calldata on %s is not labeled as an Ethereum protocol action', async (_name, chainId) => {
+    const parsed = await parseEthTx(
+      tx({ to: EIGENLAYER_DELEGATION_MANAGER_ADDRESS, data: delegateToCalldata, chainId }),
+    );
+
+    expect(parsed).not.toHaveProperty('inputData');
+  });
+
+  test('a transaction with no chain id at all is not labeled either', async () => {
+    const parsed = await parseEthTx(tx({ to: EIGENLAYER_DELEGATION_MANAGER_ADDRESS, data: delegateToCalldata }));
+
+    expect(parsed).not.toHaveProperty('inputData');
+  });
+
+  test('the Ethereum testnets Kiln uses still decode', async () => {
+    const requestExit = encodeFunctionData({
+      abi: parseAbi(['function requestExit(bytes[] validators_) external']),
+      functionName: 'requestExit',
+      args: [[`0x${'ab'.repeat(48)}`]],
+    });
+
+    for (const chainId of ['11155111', '560048']) {
+      const parsed = await parseEthTx(tx({ to: ETH_EXIT_CONTRACT_ADDRESS, data: requestExit, chainId }));
+      expect(parsed).toMatchObject({ inputData: { functionName: 'requestExit' } });
+    }
+  });
+});
+
+describe('chain-agnostic token standards still decode anywhere', () => {
+  test('an ERC-20 approve decodes on Base, since the selector alone identifies it', async () => {
+    const approve = encodeFunctionData({
+      abi: parseAbi(['function approve(address spender, uint256 amount) returns (bool)']),
+      functionName: 'approve',
+      args: ['0x2222222222222222222222222222222222222222', 1n],
+    });
+
+    const parsed = await parseEthTx(
+      tx({ to: '0x3333333333333333333333333333333333333333', data: approve, chainId: '8453' }),
+    );
+
+    expect(parsed).toMatchObject({ inputData: { functionName: 'approve' } });
+  });
+});

--- a/apps/ethereum/src/parser.ts
+++ b/apps/ethereum/src/parser.ts
@@ -99,7 +99,10 @@ export const parseEthTx = async (txRaw: string): Promise<AugmentedTransaction> =
     if (looksLikeObject(txRaw)) {
       const tx = JSON.parse(txRaw);
       // Never trust caller-supplied inputData — always derive from actual calldata.
-      delete (tx as AugmentedTransactionWithFunction).inputData;
+      // Asserted as an object that may carry the property rather than as the augmented
+      // type: this is unvalidated caller JSON, and delete needs the property optional
+      // (TS2790). Its value type is irrelevant to a delete.
+      delete (tx as { inputData?: unknown }).inputData;
       const inputData = await tryDecodeInputData(tx);
       if (inputData) {
         (tx as AugmentedTransactionWithFunction).inputData = inputData;

--- a/apps/ethereum/src/parser.ts
+++ b/apps/ethereum/src/parser.ts
@@ -57,7 +57,7 @@ const tryDecodeInputData = async (tx: AugmentedTransaction) => {
   // Only apply the hardcoded protocol ABIs (keyed by contract address) when the
   // transaction targets a supported Ethereum chain. The same address may be empty,
   // attacker-controlled, or a different contract on another EVM chain, so matching by
-  // address alone would produce a false protocol attribution (see SEC-358).
+  // address alone would produce a false protocol attribution.
   if (isSupportedEthereumChain(tx.chainId)) {
     const contractAddress = tx.to;
     const matchingAddress = Object.keys(ABIS)

--- a/apps/ethereum/src/parser.ts
+++ b/apps/ethereum/src/parser.ts
@@ -54,9 +54,7 @@ const tryDecodeInputData = async (tx: AugmentedTransaction) => {
     return null;
   }
 
-  // Only apply the hardcoded protocol ABIs (keyed by contract address) when the
-  // transaction targets a supported Ethereum chain. The same address may be empty,
-  // attacker-controlled, or a different contract on another EVM chain, so matching by
+  // The same address may be empty or attacker-controlled on another EVM chain, so matching by
   // address alone would produce a false protocol attribution.
   if (isSupportedEthereumChain(tx.chainId)) {
     const contractAddress = tx.to;

--- a/apps/ethereum/src/parser.ts
+++ b/apps/ethereum/src/parser.ts
@@ -10,7 +10,7 @@ import {
   serializeTransaction,
 } from 'viem';
 import { formatAbiItem } from 'viem/utils';
-import { ABIS, type ContractAbi } from '@/constant';
+import { ABIS, type ContractAbi, ETHEREUM_CHAIN_IDS } from '@/constant';
 import type { AugmentedTransaction, AugmentedTransactionWithFunction } from '@/types';
 import { normalizeHex } from '@/utils';
 
@@ -45,20 +45,30 @@ const tryDecodeWithAbi = async (tx: AugmentedTransaction, abi: ContractAbi) => {
   }
 };
 
+const isSupportedEthereumChain = (chainId: AugmentedTransaction['chainId']): boolean => {
+  return chainId !== undefined && ETHEREUM_CHAIN_IDS.includes(Number(chainId));
+};
+
 const tryDecodeInputData = async (tx: AugmentedTransaction) => {
   if (!tx.data || !tx.to) {
     return null;
   }
 
-  const contractAddress = tx.to;
-  const matchingAddress = Object.keys(ABIS)
-    .filter((addr) => isAddress(addr))
-    .find((addr) => isAddressEqual(addr as `0x${string}`, contractAddress)) as keyof typeof ABIS;
+  // Only apply the hardcoded protocol ABIs (keyed by contract address) when the
+  // transaction targets a supported Ethereum chain. The same address may be empty,
+  // attacker-controlled, or a different contract on another EVM chain, so matching by
+  // address alone would produce a false protocol attribution (see SEC-358).
+  if (isSupportedEthereumChain(tx.chainId)) {
+    const contractAddress = tx.to;
+    const matchingAddress = Object.keys(ABIS)
+      .filter((addr) => isAddress(addr))
+      .find((addr) => isAddressEqual(addr as `0x${string}`, contractAddress)) as keyof typeof ABIS;
 
-  if (matchingAddress) {
-    const result = await tryDecodeWithAbi(tx, ABIS[matchingAddress]);
-    if (result) {
-      return result;
+    if (matchingAddress) {
+      const result = await tryDecodeWithAbi(tx, ABIS[matchingAddress]);
+      if (result) {
+        return result;
+      }
     }
   }
 

--- a/apps/ethereum/src/utils.tsx
+++ b/apps/ethereum/src/utils.tsx
@@ -29,12 +29,14 @@ export function shortenAddress(address: `0x${string}`): string {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
 }
 
-type RiskLevel = 'low' | 'medium' | 'high' | 'unknown';
-
+/**
+ * What the transaction does, in the user's words. Deliberately no risk level and no warning:
+ * every handler used to return 'high' with a matching "X is a high risk operation" string, so
+ * the badge said HIGH RISK on every transaction ever decoded and carried no information. Judging
+ * the transaction is the verdict's job now — see kiln-operations.ts.
+ */
 type DetailsResult = {
   description: ReactNode;
-  riskLevel: RiskLevel;
-  warning: string;
 };
 
 const ACTION_HANDLERS = {
@@ -49,8 +51,6 @@ const ACTION_HANDLERS = {
           Batch staking {ethAmount} ETH for {dataRoots.length} validator(s)
         </div>
       ),
-      riskLevel: 'high',
-      warning: 'Batch staking is a high risk operation',
     };
   },
   batchDepositCustom: (tx) => {
@@ -64,8 +64,6 @@ const ACTION_HANDLERS = {
           Batch staking {ethAmount} ETH for {dataRoots.length} validator(s)
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Batch staking is a high risk operation',
     };
   },
   buyVoucher: (tx) => {
@@ -76,8 +74,6 @@ const ACTION_HANDLERS = {
           Delegating {formatEther(amount)} tokens (min shares: {formatEther(minShares)})
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Delegating is a high risk operation',
     };
   },
   sellVoucher: (tx) => {
@@ -91,15 +87,11 @@ const ACTION_HANDLERS = {
           Undelegating {formatEther(claimAmount)} tokens (max shares: {formatEther(maxShares)})
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Undelegating is a high risk operation',
     };
   },
   unstakeClaimTokens: (_tx) => {
     return {
       description: 'Claiming unstaked tokens',
-      riskLevel: 'high',
-      warning: 'Claiming unstaked tokens is a high risk operation',
     };
   },
   withdrawRewards: (tx) => {
@@ -110,15 +102,11 @@ const ACTION_HANDLERS = {
           Withdrawing rewards from <AddressComponent address={to} explorerLink={ethExplorerLink(to, 'address')} />
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Withdrawing rewards is a high risk operation',
     };
   },
   restake: (_tx) => {
     return {
       description: 'Restaking rewards',
-      riskLevel: 'high',
-      warning: 'Restaking rewards is a high risk operation',
     };
   },
   buyVoucherPOL: (tx) => {
@@ -132,8 +120,6 @@ const ACTION_HANDLERS = {
           Delegating {formatEther(amount)} POL tokens (min shares: {formatEther(minShares)})
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Delegating POL tokens is a high risk operation',
     };
   },
   sellVoucherPOL: (tx) => {
@@ -147,51 +133,37 @@ const ACTION_HANDLERS = {
           Undelegating {formatEther(claimAmount)} POL tokens (max shares: {formatEther(maxShares)})
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Undelegating POL tokens is a high risk operation',
     };
   },
   withdrawRewardsPOL: (tx) => {
     const to = tx.to ?? '0x';
     return {
       description: <>Withdrawing POL rewards from {shortenAddress(to)}</>,
-      riskLevel: 'high',
-      warning: 'Withdrawing POL rewards is a high risk operation',
     };
   },
   restakePOL: (_tx) => {
     return {
       description: 'Restaking POL rewards',
-      riskLevel: 'high',
-      warning: 'Restaking POL rewards is a high risk operation',
     };
   },
   undelegate: (_tx) => {
     return {
       description: 'Undelegating from EigenLayer operator',
-      riskLevel: 'high',
-      warning: 'Undelegating from EigenLayer operator is a high risk operation',
     };
   },
   delegateTo: (_tx) => {
     return {
       description: 'Delegating to EigenLayer operator',
-      riskLevel: 'high',
-      warning: 'Delegating to EigenLayer operator is a high risk operation',
     };
   },
   completeQueuedWithdrawals: (_tx) => {
     return {
       description: 'Completing queued EigenLayer withdrawals',
-      riskLevel: 'high',
-      warning: 'Completing queued EigenLayer withdrawals is a high risk operation',
     };
   },
   createPod: (_tx) => {
     return {
       description: 'Creating EigenLayer Pod',
-      riskLevel: 'high',
-      warning: 'Creating EigenLayer Pod is a high risk operation',
     };
   },
   approve: (tx) => {
@@ -204,15 +176,11 @@ const ACTION_HANDLERS = {
           Approving {amount.toString()} tokens for {shortenAddress(spender)}
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Approving tokens is a high risk operation',
     };
   },
   multiClaim: (_tx) => {
     return {
       description: 'Claiming multiple exit tickets',
-      riskLevel: 'high',
-      warning: 'Claiming multiple exit tickets is a high risk operation',
     };
   },
   stake: (tx) => {
@@ -225,8 +193,6 @@ const ACTION_HANDLERS = {
           Staking {ethAmount} ETH to {shortenAddress(to)}
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Staking ETH is a high risk operation',
     };
   },
   deposit: (tx) => {
@@ -240,16 +206,12 @@ const ACTION_HANDLERS = {
           Depositing {ethAmount} ETH{hasEthValue ? '' : ' tokens'} to {shortenAddress(to)}
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Depositing ETH is a high risk operation',
     };
   },
   redeem: (tx) => {
     const to = tx.to ?? '0x';
     return {
       description: <>Redeeming tokens from {shortenAddress(to)}</>,
-      riskLevel: 'high',
-      warning: 'Redeeming tokens is a high risk operation',
     };
   },
   withdraw: (tx) => {
@@ -262,23 +224,17 @@ const ACTION_HANDLERS = {
           Withdrawing {ethAmount} tokens from {shortenAddress(to)}
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Withdrawing tokens is a high risk operation',
     };
   },
   requestValidatorsExit: () => {
     return {
       description: 'Requesting validator exit',
-      riskLevel: 'high',
-      warning: 'Requesting validator exit is a high risk operation',
     };
   },
   requestExit: (tx) => {
     const [validators] = tx.inputData.args as ExtractArgs<typeof ETH_EXIT_CONTRACT_ABI, 'requestExit'>;
     return {
       description: <>Requesting validator exit for {validators.length} validator(s)</>,
-      riskLevel: 'high',
-      warning: 'Requesting validator exit is a high risk operation',
     };
   },
   bigBatchDeposit: (tx) => {
@@ -291,8 +247,6 @@ const ACTION_HANDLERS = {
           Big batch staking {ethAmount} ETH for {validators.length} validator(s)
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Big batch staking is a high risk operation',
     };
   },
   bigBatchDepositCustom: (tx) => {
@@ -305,40 +259,30 @@ const ACTION_HANDLERS = {
           Big batch staking {ethAmount} ETH for {validators.length} validator(s)
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Big batch staking is a high risk operation',
     };
   },
   delegatedTo: (tx) => {
     const to = tx.to ?? '0x';
     return {
       description: <>Delegating to {shortenAddress(to)}</>,
-      riskLevel: 'high',
-      warning: 'Delegating to EigenLayer operator is a high risk operation',
     };
   },
   maxWithdraw: (tx) => {
     const to = tx.to ?? '0x';
     return {
       description: <>Withdrawing max tokens from {shortenAddress(to)}</>,
-      riskLevel: 'high',
-      warning: 'Withdrawing max tokens is a high risk operation',
     };
   },
   withdrawableRestakedExecutionLayerGwei: (tx) => {
     const to = tx.to ?? '0x';
     return {
       description: <>Withdrawing restaked execution layer Gwei from {shortenAddress(to)}</>,
-      riskLevel: 'high',
-      warning: 'Withdrawing restaked execution layer Gwei is a high risk operation',
     };
   },
   cancelRequestDeposit: (tx) => {
     const to = tx.to ?? '0x';
     return {
       description: <>Cancelling deposit request on vault {shortenAddress(to)}</>,
-      riskLevel: 'high',
-      warning: 'Cancelling a deposit request is a high risk operation',
     };
   },
   updateNewTotalAssets: (tx) => {
@@ -351,8 +295,6 @@ const ACTION_HANDLERS = {
           Updating NAV to {newTotalAssets.toString()} on vault {shortenAddress(to)}
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Updating NAV is a high risk operation',
     };
   },
   requestDeposit: (tx) => {
@@ -365,8 +307,6 @@ const ACTION_HANDLERS = {
           Requesting deposit of {assets.toString()} assets on vault {shortenAddress(to)}
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Requesting a deposit is a high risk operation',
     };
   },
   requestRedeem: (tx) => {
@@ -379,8 +319,6 @@ const ACTION_HANDLERS = {
           Requesting withdrawal of {shares.toString()} shares on vault {shortenAddress(to)}
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Requesting a withdrawal is a high risk operation',
     };
   },
   settleDeposit: (tx) => {
@@ -393,8 +331,6 @@ const ACTION_HANDLERS = {
           Settling deposits with total assets {newTotalAssets.toString()} on vault {shortenAddress(to)}
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Settling deposits is a high risk operation',
     };
   },
   settleRedeem: (tx) => {
@@ -407,8 +343,6 @@ const ACTION_HANDLERS = {
           Settling redemptions with total assets {newTotalAssets.toString()} on vault {shortenAddress(to)}
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Settling redemptions is a high risk operation',
     };
   },
   claimSharesAndRequestRedeem: (tx) => {
@@ -421,16 +355,12 @@ const ACTION_HANDLERS = {
           Claiming shares and requesting redemption of {sharesToRedeem.toString()} shares on vault {shortenAddress(to)}
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Claiming shares and requesting redemption is a high risk operation',
     };
   },
   claimSharesOnBehalf: (tx) => {
     const to = tx.to ?? '0x';
     return {
       description: <>Claiming shares on behalf of controllers on vault {shortenAddress(to)}</>,
-      riskLevel: 'high',
-      warning: 'Claiming shares on behalf is a high risk operation',
     };
   },
   syncDeposit: (tx) => {
@@ -443,8 +373,6 @@ const ACTION_HANDLERS = {
           Depositing {assets.toString()} assets on vault {shortenAddress(to)}
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Depositing assets is a high risk operation',
     };
   },
   close: (tx) => {
@@ -457,8 +385,6 @@ const ACTION_HANDLERS = {
           Closing vault {shortenAddress(to)} with total assets {newTotalAssets.toString()}
         </>
       ),
-      riskLevel: 'high',
-      warning: 'Closing a vault is a high risk operation',
     };
   },
 } satisfies Record<keyof FunctionNameToAbiMap, (tx: AugmentedTransactionWithFunction) => DetailsResult>;
@@ -471,15 +397,12 @@ export function getActionDetails(tx: AugmentedTransaction): DetailsResult {
   if (!tx.to)
     return {
       description: 'Unknown transaction',
-      riskLevel: 'unknown',
-      warning: 'Unknown transaction proceed with caution',
     };
 
   const to = tx.to as `0x${string}`;
   const valueWei = tx.value ? BigInt(tx.value) : 0n;
   const ethAmount = formatEther(valueWei);
   const hasEthValue = valueWei > 0n;
-  const isHighValue = parseFloat(ethAmount) > 1;
 
   if (!isTransactionWithInputData(tx)) {
     if (hasEthValue) {
@@ -489,14 +412,10 @@ export function getActionDetails(tx: AugmentedTransaction): DetailsResult {
             Sending {ethAmount} ETH to <AddressComponent address={to} explorerLink={ethExplorerLink(to, 'address')} />
           </>
         ),
-        riskLevel: isHighValue ? 'high' : 'low',
-        warning: '',
       };
     }
     return {
       description: <>Calling contract {shortenAddress(to)}</>,
-      riskLevel: 'low',
-      warning: '',
     };
   }
 
@@ -504,8 +423,6 @@ export function getActionDetails(tx: AugmentedTransaction): DetailsResult {
   if (!(funcName in ACTION_HANDLERS)) {
     return {
       description: <>Unknown function: {funcName}</>,
-      riskLevel: 'unknown',
-      warning: 'Unknown function proceed with caution',
     };
   }
   const handler = ACTION_HANDLERS[funcName as keyof FunctionNameToAbiMap];

--- a/apps/ethereum/src/utils.tsx
+++ b/apps/ethereum/src/utils.tsx
@@ -29,12 +29,7 @@ export function shortenAddress(address: `0x${string}`): string {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
 }
 
-/**
- * What the transaction does, in the user's words. Deliberately no risk level and no warning:
- * every handler used to return 'high' with a matching "X is a high risk operation" string, so
- * the badge said HIGH RISK on every transaction ever decoded and carried no information. Judging
- * the transaction is the verdict's job now — see kiln-operations.ts.
- */
+/** What the transaction does. Judging it is the verdict's job — see kiln-operations.ts. */
 type DetailsResult = {
   description: ReactNode;
 };

--- a/apps/ethereum/tsconfig.json
+++ b/apps/ethereum/tsconfig.json
@@ -8,5 +8,6 @@
       "@protocols/shared": ["../../packages/shared/src"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }

--- a/apps/near/src/kiln-operations.test.ts
+++ b/apps/near/src/kiln-operations.test.ts
@@ -4,10 +4,7 @@ import { actionCreators, createTransaction, encodeTransaction } from '@near-js/t
 import { classifyNearTransaction } from '@/kiln-operations';
 import { parseNearTx } from '@/parser';
 
-/**
- * The actions below mirror how Kiln's transaction-crafting API builds each operation, so a change on either
- * side shows up here rather than in production.
- */
+/** These mirror how Kiln crafts each operation, so a drift on either side shows up here. */
 
 const { addKey, deleteAccount, deployContract, functionCall, fullAccessKey, transfer } = actionCreators;
 

--- a/apps/near/src/kiln-operations.test.ts
+++ b/apps/near/src/kiln-operations.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'bun:test';
+import { KeyPair } from '@near-js/crypto';
+import { actionCreators, createTransaction, encodeTransaction } from '@near-js/transactions';
+import { classifyNearTransaction } from '@/kiln-operations';
+import { parseNearTx } from '@/parser';
+
+/**
+ * The actions below mirror how services/sof/tx builds each operation, so a change on either
+ * side shows up here rather than in production.
+ */
+
+const { addKey, deleteAccount, deployContract, functionCall, fullAccessKey, transfer } = actionCreators;
+
+const wallet = 'kiln-customer.near';
+const pool = 'kiln.pool.near';
+const publicKey = KeyPair.fromRandom('ed25519').getPublicKey();
+const blockHash = new Uint8Array(32).fill(1);
+
+/** 300 Tgas — what NearService attaches to every call it crafts. */
+const MAX_GAS = 300_000_000_000_000n;
+
+/** Serialize an unsigned transaction the way minitel receives it, then run the real parser. */
+const classify = (actions: ReturnType<typeof transfer>[]) => {
+  const tx = createTransaction(wallet, publicKey, pool, 1n, actions, blockHash);
+  const hex = Buffer.from(encodeTransaction(tx)).toString('hex');
+  return classifyNearTransaction(parseNearTx(hex));
+};
+
+describe('Kiln NEAR operations are recognized', () => {
+  test('stake — deposit_and_stake with the staked amount attached', () => {
+    const verdict = classify([functionCall('deposit_and_stake', {}, MAX_GAS, 1_000_000_000_000_000_000_000_000n)]);
+
+    expect(verdict.status).toBe('recognized');
+    expect(verdict).toMatchObject({ operation: 'stake' });
+  });
+
+  test('unstake — a partial unstake carries the amount in args', () => {
+    const verdict = classify([functionCall('unstake', { amount: '1000' }, MAX_GAS, 0n)]);
+
+    expect(verdict.status).toBe('recognized');
+    expect(verdict).toMatchObject({ operation: 'unstake' });
+  });
+
+  test('unstake — unstake_all is crafted with no args', () => {
+    const verdict = classify([functionCall('unstake_all', {}, MAX_GAS, 0n)]);
+
+    expect(verdict.status).toBe('recognized');
+    expect(verdict).toMatchObject({ operation: 'unstake' });
+  });
+
+  test('withdraw — a partial withdrawal carries the amount in args', () => {
+    const verdict = classify([functionCall('withdraw', { amount: '1000' }, MAX_GAS, 0n)]);
+
+    expect(verdict.status).toBe('recognized');
+    expect(verdict).toMatchObject({ operation: 'withdraw' });
+  });
+
+  test('withdraw — withdraw_all is crafted with no args', () => {
+    const verdict = classify([functionCall('withdraw_all', {}, MAX_GAS, 0n)]);
+
+    expect(verdict.status).toBe('recognized');
+    expect(verdict).toMatchObject({ operation: 'withdraw' });
+  });
+});
+
+describe('Non-Kiln NEAR transactions are rejected', () => {
+  test('a plain NEAR transfer', () => {
+    const verdict = classify([transfer(1_000_000_000_000_000_000_000_000n)]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('plain NEAR transfer') });
+  });
+
+  test('a function call to a method Kiln never uses', () => {
+    const verdict = classify([functionCall('ft_transfer', { receiver_id: 'attacker.near' }, MAX_GAS, 1n)]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('ft_transfer()') });
+  });
+
+  test('adding a full access key', () => {
+    const verdict = classify([addKey(KeyPair.fromRandom('ed25519').getPublicKey(), fullAccessKey())]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('access key addition') });
+  });
+
+  test('deleting the account', () => {
+    const verdict = classify([deleteAccount('attacker.near')]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('account deletion') });
+  });
+
+  test('deploying a contract', () => {
+    const verdict = classify([deployContract(new Uint8Array([0, 97, 115, 109]))]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('contract deployment') });
+  });
+
+  test('a transfer smuggled alongside a valid unstake', () => {
+    const verdict = classify([
+      functionCall('unstake_all', {}, MAX_GAS, 0n),
+      transfer(1_000_000_000_000_000_000_000_000n),
+    ]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('bundles 2 actions') });
+  });
+
+  test('withdraw_all with a deposit attached', () => {
+    const verdict = classify([functionCall('withdraw_all', {}, MAX_GAS, 1_000_000_000_000_000_000_000_000n)]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('attaches a deposit') });
+  });
+
+  test('a transaction with no actions at all', () => {
+    const verdict = classify([]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('no actions') });
+  });
+});

--- a/apps/near/src/kiln-operations.test.ts
+++ b/apps/near/src/kiln-operations.test.ts
@@ -5,7 +5,7 @@ import { classifyNearTransaction } from '@/kiln-operations';
 import { parseNearTx } from '@/parser';
 
 /**
- * The actions below mirror how services/sof/tx builds each operation, so a change on either
+ * The actions below mirror how Kiln's transaction-crafting API builds each operation, so a change on either
  * side shows up here rather than in production.
  */
 
@@ -16,7 +16,7 @@ const pool = 'kiln.pool.near';
 const publicKey = KeyPair.fromRandom('ed25519').getPublicKey();
 const blockHash = new Uint8Array(32).fill(1);
 
-/** 300 Tgas — what NearService attaches to every call it crafts. */
+/** 300 Tgas — what Kiln attaches to every call it crafts. */
 const MAX_GAS = 300_000_000_000_000n;
 
 /** Serialize an unsigned transaction the way minitel receives it, then run the real parser. */

--- a/apps/near/src/kiln-operations.ts
+++ b/apps/near/src/kiln-operations.ts
@@ -2,21 +2,12 @@ import { recognized, type TransactionVerdict, unrecognized } from '@protocols/sh
 import type { DecodedAction, NearTransaction } from '@/parser';
 
 /**
- * The NEAR operations Kiln crafts, and the shape each one has.
- *
- * Source of truth is Kiln's transaction-crafting API:
- * `/near/transaction/{stake,unstake,withdraw}`, which the public Kiln Connect spec exposes
- * unchanged. Every one of them builds exactly one FunctionCall against the staking pool, so a
- * genuine Kiln transaction is a single action and nothing else.
- *
- * Matching is on that shape — one function call, a known method, no unexpected deposit — not
- * on the pool account it targets. The pool list lives in Kiln's configuration and changes
- * without minitel knowing; baking it in here would produce a list that silently goes stale and
- * starts rejecting real transactions. The decoded summary below the verdict is where the user
- * checks which pool they are staking with.
+ * Kiln's NEAR routes — /near/transaction/{stake,unstake,withdraw} — each build exactly one
+ * FunctionCall against the staking pool. Matched on that shape, not on the pool account: the
+ * pool list is Kiln configuration and would go stale here.
  */
 
-/** Human-readable name for an action, used only to explain a rejection. */
+/** Used only to explain a rejection. */
 const describeAction = (action: DecodedAction): string => {
   switch (action.type) {
     case 'functionCall':
@@ -47,8 +38,7 @@ export const classifyNearTransaction = (transaction: NearTransaction): Transacti
     return unrecognized('This transaction contains no actions.');
   }
 
-  // Kiln never batches: stake, unstake and withdraw are each a single FunctionCall. A second
-  // action is something we did not craft, however innocent the first one looks.
+  // Kiln never batches, so a second action is something we did not craft.
   if (actions.length > 1) {
     return unrecognized(
       `This transaction bundles ${actions.length} actions (${actions.map(describeAction).join(', ')}). Kiln operations on NEAR carry exactly one.`,
@@ -65,8 +55,7 @@ export const classifyNearTransaction = (transaction: NearTransaction): Transacti
     return unrecognized(`This transaction calls ${action.methodName}(), which is not a method Kiln operations use.`);
   }
 
-  // unstake and withdraw are crafted with a zero deposit — they move stake that is already in
-  // the pool. An attached deposit on either one sends NEAR the user is not expecting to send.
+  // unstake and withdraw move stake already in the pool, so a deposit sends unexpected NEAR.
   if (action.stakingOperation !== 'stake' && action.deposit !== '0') {
     return unrecognized(
       `This ${action.methodName}() call attaches a deposit of ${action.deposit} yoctoNEAR. Kiln crafts it with no deposit.`,

--- a/apps/near/src/kiln-operations.ts
+++ b/apps/near/src/kiln-operations.ts
@@ -4,7 +4,7 @@ import type { DecodedAction, NearTransaction } from '@/parser';
 /**
  * The NEAR operations Kiln crafts, and the shape each one has.
  *
- * Source of truth is the crafting service (services/sof/tx, NearController + NearService):
+ * Source of truth is Kiln's transaction-crafting API:
  * `/near/transaction/{stake,unstake,withdraw}`, which the public Kiln Connect spec exposes
  * unchanged. Every one of them builds exactly one FunctionCall against the staking pool, so a
  * genuine Kiln transaction is a single action and nothing else.

--- a/apps/near/src/kiln-operations.ts
+++ b/apps/near/src/kiln-operations.ts
@@ -1,0 +1,77 @@
+import { recognized, type TransactionVerdict, unrecognized } from '@protocols/shared';
+import type { DecodedAction, NearTransaction } from '@/parser';
+
+/**
+ * The NEAR operations Kiln crafts, and the shape each one has.
+ *
+ * Source of truth is the crafting service (services/sof/tx, NearController + NearService):
+ * `/near/transaction/{stake,unstake,withdraw}`, which the public Kiln Connect spec exposes
+ * unchanged. Every one of them builds exactly one FunctionCall against the staking pool, so a
+ * genuine Kiln transaction is a single action and nothing else.
+ *
+ * Matching is on that shape — one function call, a known method, no unexpected deposit — not
+ * on the pool account it targets. The pool list lives in Kiln's configuration and changes
+ * without minitel knowing; baking it in here would produce a list that silently goes stale and
+ * starts rejecting real transactions. The decoded summary below the verdict is where the user
+ * checks which pool they are staking with.
+ */
+
+/** Human-readable name for an action, used only to explain a rejection. */
+const describeAction = (action: DecodedAction): string => {
+  switch (action.type) {
+    case 'functionCall':
+      return `a call to ${action.methodName}()`;
+    case 'transfer':
+      return 'a plain NEAR transfer';
+    case 'createAccount':
+      return 'an account creation';
+    case 'deleteAccount':
+      return 'an account deletion';
+    case 'addKey':
+      return 'an access key addition';
+    case 'deleteKey':
+      return 'an access key removal';
+    case 'deployContract':
+      return 'a contract deployment';
+    case 'stake':
+      return 'a native validator stake';
+    default:
+      return 'an action minitel could not decode';
+  }
+};
+
+export const classifyNearTransaction = (transaction: NearTransaction): TransactionVerdict => {
+  const { actions } = transaction;
+
+  if (actions.length === 0) {
+    return unrecognized('This transaction contains no actions.');
+  }
+
+  // Kiln never batches: stake, unstake and withdraw are each a single FunctionCall. A second
+  // action is something we did not craft, however innocent the first one looks.
+  if (actions.length > 1) {
+    return unrecognized(
+      `This transaction bundles ${actions.length} actions (${actions.map(describeAction).join(', ')}). Kiln operations on NEAR carry exactly one.`,
+    );
+  }
+
+  const action = actions[0];
+
+  if (action.type !== 'functionCall') {
+    return unrecognized(`This transaction is ${describeAction(action)}, not a Kiln staking operation.`);
+  }
+
+  if (action.stakingOperation === null) {
+    return unrecognized(`This transaction calls ${action.methodName}(), which is not a method Kiln operations use.`);
+  }
+
+  // unstake and withdraw are crafted with a zero deposit — they move stake that is already in
+  // the pool. An attached deposit on either one sends NEAR the user is not expecting to send.
+  if (action.stakingOperation !== 'stake' && action.deposit !== '0') {
+    return unrecognized(
+      `This ${action.methodName}() call attaches a deposit of ${action.deposit} yoctoNEAR. Kiln crafts it with no deposit.`,
+    );
+  }
+
+  return recognized(action.stakingOperation);
+};

--- a/apps/near/src/near-adapter.tsx
+++ b/apps/near/src/near-adapter.tsx
@@ -1,4 +1,4 @@
-import { NEAR, type ProtocolAdapter } from '@protocols/shared';
+import { NEAR, type ProtocolAdapter, pendingAllowlist } from '@protocols/shared';
 import { TransactionSummary } from '@/components/TransactionSummary';
 import { type NearTransaction, parseNearTx } from '@/parser';
 
@@ -32,6 +32,10 @@ export const nearAdapter: ProtocolAdapter<NearTransaction> = {
   computeHash: computeNearHash,
 
   renderSummary: (data) => <TransactionSummary transaction={data} />,
+
+  // Kiln crafts stake, unstake and withdraw on NEAR. The parser already resolves each function
+  // call to a stakingOperation or null, so this is a short step from a real allowlist.
+  classifyTransaction: pendingAllowlist,
 
   generateWarnings: (data) => {
     const warnings: { message: string }[] = [];

--- a/apps/near/src/near-adapter.tsx
+++ b/apps/near/src/near-adapter.tsx
@@ -1,5 +1,6 @@
-import { NEAR, type ProtocolAdapter, pendingAllowlist } from '@protocols/shared';
+import { NEAR, type ProtocolAdapter } from '@protocols/shared';
 import { TransactionSummary } from '@/components/TransactionSummary';
+import { classifyNearTransaction } from '@/kiln-operations';
 import { type NearTransaction, parseNearTx } from '@/parser';
 
 const isValidNearInput = (rawTx: string): boolean => {
@@ -33,9 +34,7 @@ export const nearAdapter: ProtocolAdapter<NearTransaction> = {
 
   renderSummary: (data) => <TransactionSummary transaction={data} />,
 
-  // Kiln crafts stake, unstake and withdraw on NEAR. The parser already resolves each function
-  // call to a stakingOperation or null, so this is a short step from a real allowlist.
-  classifyTransaction: pendingAllowlist,
+  classifyTransaction: classifyNearTransaction,
 
   generateWarnings: (data) => {
     const warnings: { message: string }[] = [];

--- a/apps/near/tsconfig.json
+++ b/apps/near/tsconfig.json
@@ -8,5 +8,6 @@
       "@protocols/shared": ["../../packages/shared/src"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }

--- a/apps/solana/src/kiln-operations.test.ts
+++ b/apps/solana/src/kiln-operations.test.ts
@@ -12,10 +12,7 @@ import {
 import { classifySolanaTransaction } from '@/kiln-operations';
 import { parseSolTx } from '@/parser';
 
-/**
- * The instruction sequences below mirror how Kiln's transaction-crafting API builds each operation, so a
- * change on either side shows up here rather than in production.
- */
+/** These mirror how Kiln crafts each operation, so a drift on either side shows up here. */
 
 const wallet = Keypair.generate().publicKey;
 const nonceAccount = Keypair.generate().publicKey;

--- a/apps/solana/src/kiln-operations.test.ts
+++ b/apps/solana/src/kiln-operations.test.ts
@@ -13,7 +13,7 @@ import { classifySolanaTransaction } from '@/kiln-operations';
 import { parseSolTx } from '@/parser';
 
 /**
- * The instruction sequences below mirror how services/sof/tx builds each operation, so a
+ * The instruction sequences below mirror how Kiln's transaction-crafting API builds each operation, so a
  * change on either side shows up here rather than in production.
  */
 

--- a/apps/solana/src/kiln-operations.test.ts
+++ b/apps/solana/src/kiln-operations.test.ts
@@ -9,8 +9,8 @@ import {
   Transaction,
   TransactionInstruction,
 } from '@solana/web3.js';
-import { classifySolanaTransaction } from './kiln-operations';
-import { parseSolTx } from './parser';
+import { classifySolanaTransaction } from '@/kiln-operations';
+import { parseSolTx } from '@/parser';
 
 /**
  * The instruction sequences below mirror how services/sof/tx builds each operation, so a
@@ -22,8 +22,7 @@ const nonceAccount = Keypair.generate().publicKey;
 const stakeAccount = Keypair.generate().publicKey;
 const voteAccount = Keypair.generate().publicKey;
 
-const nonceAdvance = () =>
-  SystemProgram.nonceAdvance({ noncePubkey: nonceAccount, authorizedPubkey: wallet });
+const nonceAdvance = () => SystemProgram.nonceAdvance({ noncePubkey: nonceAccount, authorizedPubkey: wallet });
 
 /** Serialize an unsigned transaction the way minitel receives it, then run the real parser. */
 const classify = async (tx: Transaction) => {

--- a/apps/solana/src/kiln-operations.test.ts
+++ b/apps/solana/src/kiln-operations.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  Authorized,
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  StakeProgram,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js';
+import { classifySolanaTransaction } from './kiln-operations';
+import { parseSolTx } from './parser';
+
+/**
+ * The instruction sequences below mirror how services/sof/tx builds each operation, so a
+ * change on either side shows up here rather than in production.
+ */
+
+const wallet = Keypair.generate().publicKey;
+const nonceAccount = Keypair.generate().publicKey;
+const stakeAccount = Keypair.generate().publicKey;
+const voteAccount = Keypair.generate().publicKey;
+
+const nonceAdvance = () =>
+  SystemProgram.nonceAdvance({ noncePubkey: nonceAccount, authorizedPubkey: wallet });
+
+/** Serialize an unsigned transaction the way minitel receives it, then run the real parser. */
+const classify = async (tx: Transaction) => {
+  tx.feePayer = wallet;
+  tx.recentBlockhash = new PublicKey(Buffer.alloc(32, 1)).toBase58();
+  const hex = tx.serialize({ requireAllSignatures: false, verifySignatures: false }).toString('hex');
+  const parsed = await parseSolTx(hex);
+  return classifySolanaTransaction(parsed.instructions);
+};
+
+describe('Kiln Solana operations are recognized', () => {
+  test('stake — nonce advance, create stake account, delegate', async () => {
+    const tx = new Transaction().add(
+      nonceAdvance(),
+      StakeProgram.createAccount({
+        fromPubkey: wallet,
+        authorized: new Authorized(wallet, wallet),
+        lamports: 1_000_000_000,
+        stakePubkey: stakeAccount,
+      }),
+      StakeProgram.delegate({ stakePubkey: stakeAccount, authorizedPubkey: wallet, votePubkey: voteAccount }),
+    );
+
+    const verdict = await classify(tx);
+    expect(verdict.status).toBe('recognized');
+    expect(verdict).toMatchObject({ operation: 'stake' });
+  });
+
+  test('deactivate-stake', async () => {
+    const tx = new Transaction().add(
+      nonceAdvance(),
+      StakeProgram.deactivate({ stakePubkey: stakeAccount, authorizedPubkey: wallet }),
+    );
+
+    expect(await classify(tx)).toMatchObject({ status: 'recognized', operation: 'deactivate-stake' });
+  });
+
+  test('withdraw-stake', async () => {
+    const tx = new Transaction().add(
+      nonceAdvance(),
+      StakeProgram.withdraw({
+        stakePubkey: stakeAccount,
+        authorizedPubkey: wallet,
+        toPubkey: wallet,
+        lamports: 1_000,
+      }),
+    );
+
+    expect(await classify(tx)).toMatchObject({ status: 'recognized', operation: 'withdraw-stake' });
+  });
+
+  test('merge-stakes', async () => {
+    const tx = new Transaction().add(
+      nonceAdvance(),
+      StakeProgram.merge({
+        stakePubkey: stakeAccount,
+        sourceStakePubKey: Keypair.generate().publicKey,
+        authorizedPubkey: wallet,
+      }),
+    );
+
+    expect(await classify(tx)).toMatchObject({ status: 'recognized', operation: 'merge-stakes' });
+  });
+
+  test('split-stake', async () => {
+    const tx = new Transaction().add(
+      nonceAdvance(),
+      StakeProgram.split(
+        {
+          stakePubkey: stakeAccount,
+          authorizedPubkey: wallet,
+          splitStakePubkey: Keypair.generate().publicKey,
+          lamports: 1_000_000,
+        },
+        2_282_880,
+      ),
+    );
+
+    expect(await classify(tx)).toMatchObject({ status: 'recognized', operation: 'split-stake' });
+  });
+
+  test('compute budget and memo instructions do not change the verdict', async () => {
+    const tx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }),
+      ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1_000 }),
+      nonceAdvance(),
+      StakeProgram.deactivate({ stakePubkey: stakeAccount, authorizedPubkey: wallet }),
+      new TransactionInstruction({
+        keys: [{ pubkey: wallet, isSigner: true, isWritable: true }],
+        data: Buffer.from('kiln', 'utf-8'),
+        programId: new PublicKey('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'),
+      }),
+    );
+
+    expect(await classify(tx)).toMatchObject({ status: 'recognized', operation: 'deactivate-stake' });
+  });
+});
+
+describe('Everything else fails closed', () => {
+  test('a plain SOL transfer is not a Kiln operation', async () => {
+    const tx = new Transaction().add(
+      SystemProgram.transfer({ fromPubkey: wallet, toPubkey: Keypair.generate().publicKey, lamports: 5_000 }),
+    );
+
+    expect(await classify(tx)).toMatchObject({ status: 'unrecognized' });
+  });
+
+  test('an instruction from an unknown program is not a Kiln operation', async () => {
+    const tx = new Transaction().add(
+      new TransactionInstruction({
+        keys: [{ pubkey: wallet, isSigner: true, isWritable: true }],
+        data: Buffer.from([1, 2, 3, 4]),
+        programId: Keypair.generate().publicKey,
+      }),
+    );
+
+    expect(await classify(tx)).toMatchObject({ status: 'unrecognized' });
+  });
+
+  test('stake authority reassignment is not a Kiln operation', async () => {
+    const tx = new Transaction().add(
+      nonceAdvance(),
+      StakeProgram.authorize({
+        stakePubkey: stakeAccount,
+        authorizedPubkey: wallet,
+        newAuthorizedPubkey: Keypair.generate().publicKey,
+        stakeAuthorizationType: { index: 0 },
+      }),
+    );
+
+    expect(await classify(tx)).toMatchObject({ status: 'unrecognized' });
+  });
+
+  test('a hostile instruction smuggled alongside a valid deactivate is caught', async () => {
+    const tx = new Transaction().add(
+      nonceAdvance(),
+      StakeProgram.deactivate({ stakePubkey: stakeAccount, authorizedPubkey: wallet }),
+      SystemProgram.transfer({ fromPubkey: wallet, toPubkey: Keypair.generate().publicKey, lamports: 5_000 }),
+    );
+
+    expect(await classify(tx)).toMatchObject({ status: 'unrecognized' });
+  });
+});

--- a/apps/solana/src/kiln-operations.ts
+++ b/apps/solana/src/kiln-operations.ts
@@ -1,0 +1,100 @@
+import { recognized, type TransactionVerdict, unrecognized } from '@protocols/shared';
+import { type DecodedInstruction, getProgramKeyFromId, type InstructionType } from '@/types';
+
+/**
+ * The Solana operations Kiln crafts, and the instructions each one is made of.
+ *
+ * Source of truth is the crafting service (services/sof/tx, SolController + SolService):
+ * `/sol/transaction/{stake,deactivate-stake,withdraw-stake,split-stake,merge-stakes}`.
+ * Every one of those is built as a nonce advance followed by a single Stake Program action,
+ * so the shape of a genuine Kiln transaction is narrow and checkable.
+ *
+ * Matching is on operation shape — which programs and instructions appear — not on Kiln's
+ * own vote accounts or nonce authorities. Those live in Kiln's configuration and change
+ * without minitel knowing; baking them in here would produce a list that silently goes stale
+ * and starts rejecting real transactions, which erodes trust in the verdict just as badly as
+ * accepting a bad one. A correctly shaped stake to a validator that is not ours still reads
+ * as recognized, and the decoded summary below the verdict is where the user checks that.
+ */
+
+/**
+ * Instructions that carry no value movement and appear as envelope around real operations:
+ * fee configuration, the durable-nonce advance every Kiln transaction opens with, and the
+ * optional memo. They are ignored when matching so they cannot mask the operation itself.
+ */
+const ENVELOPE_INSTRUCTIONS: ReadonlySet<InstructionType> = new Set<InstructionType>([
+  'AdvanceNonceAccount',
+  'SetComputeUnitLimit',
+  'SetComputeUnitPrice',
+  'RequestUnits',
+  'RequestHeapFrame',
+  'Memo',
+]);
+
+/**
+ * The core instruction sequence of each Kiln operation, in order.
+ *
+ * `stake` is three instructions because StakeProgram.createAccount expands into a System
+ * Program account creation followed by the Stake Program initialize, before the delegate.
+ * `split-stake` carries the new account's rent-exempt reserve, so a System Program creation
+ * may precede the split.
+ */
+const KILN_OPERATIONS: ReadonlyArray<{ operation: string; sequences: ReadonlyArray<InstructionType[]> }> = [
+  {
+    operation: 'stake',
+    sequences: [
+      ['Create', 'Initialize', 'Delegate'],
+      ['CreateWithSeed', 'Initialize', 'Delegate'],
+    ],
+  },
+  { operation: 'deactivate-stake', sequences: [['Deactivate']] },
+  { operation: 'withdraw-stake', sequences: [['Withdraw']] },
+  {
+    operation: 'split-stake',
+    sequences: [['Split'], ['Create', 'Split'], ['Allocate', 'Assign', 'Split']],
+  },
+  { operation: 'merge-stakes', sequences: [['Merge']] },
+];
+
+const sequencesMatch = (actual: InstructionType[], expected: InstructionType[]): boolean =>
+  actual.length === expected.length && actual.every((type, index) => type === expected[index]);
+
+export const classifySolanaTransaction = (instructions: DecodedInstruction[]): TransactionVerdict => {
+  if (instructions.length === 0) {
+    return unrecognized('This transaction contains no instructions.');
+  }
+
+  // Any instruction minitel could not decode, or one from a program outside the four Kiln
+  // uses, means the transaction does something we cannot account for. Fail closed before
+  // looking at shape at all — an unreadable instruction next to a valid stake is still
+  // unreadable.
+  const undecodable = instructions.find((i) => i.type === 'unknown' || i.type === 'error');
+  if (undecodable) {
+    return unrecognized(
+      `This transaction contains an instruction minitel could not decode, from program ${undecodable.programId.toString()}.`,
+    );
+  }
+
+  const foreign = instructions.find((i) => getProgramKeyFromId(i.programId) === undefined);
+  if (foreign) {
+    return unrecognized(
+      `This transaction calls ${foreign.programId.toString()}, which is not a program Kiln operations use.`,
+    );
+  }
+
+  const core = instructions.map((i) => i.type).filter((type) => !ENVELOPE_INSTRUCTIONS.has(type));
+
+  if (core.length === 0) {
+    return unrecognized('This transaction carries no staking instruction.');
+  }
+
+  const match = KILN_OPERATIONS.find(({ sequences }) => sequences.some((sequence) => sequencesMatch(core, sequence)));
+
+  if (!match) {
+    return unrecognized(
+      `This combination of instructions (${core.join(', ')}) does not match any operation Kiln produces on Solana.`,
+    );
+  }
+
+  return recognized(match.operation);
+};

--- a/apps/solana/src/kiln-operations.ts
+++ b/apps/solana/src/kiln-operations.ts
@@ -2,26 +2,12 @@ import { recognized, type TransactionVerdict, unrecognized } from '@protocols/sh
 import { type DecodedInstruction, getProgramKeyFromId, type InstructionType } from '@/types';
 
 /**
- * The Solana operations Kiln crafts, and the instructions each one is made of.
- *
- * Source of truth is Kiln's transaction-crafting API:
- * `/sol/transaction/{stake,deactivate-stake,withdraw-stake,split-stake,merge-stakes}`.
- * Every one of those is built as a nonce advance followed by a single Stake Program action,
- * so the shape of a genuine Kiln transaction is narrow and checkable.
- *
- * Matching is on operation shape — which programs and instructions appear — not on Kiln's
- * own vote accounts or nonce authorities. Those live in Kiln's configuration and change
- * without minitel knowing; baking them in here would produce a list that silently goes stale
- * and starts rejecting real transactions, which erodes trust in the verdict just as badly as
- * accepting a bad one. A correctly shaped stake to a validator that is not ours still reads
- * as recognized, and the decoded summary below the verdict is where the user checks that.
+ * Kiln's Solana routes each build a durable-nonce advance plus one Stake Program action.
+ * Matched on instruction shape, not on Kiln's vote accounts or nonce authorities: those are
+ * Kiln configuration and would go stale here.
  */
 
-/**
- * Instructions that carry no value movement and appear as envelope around real operations:
- * fee configuration, the durable-nonce advance every Kiln transaction opens with, and the
- * optional memo. They are ignored when matching so they cannot mask the operation itself.
- */
+/** Fee config, the nonce advance and memos carry no value, so they never mask an operation. */
 const ENVELOPE_INSTRUCTIONS: ReadonlySet<InstructionType> = new Set<InstructionType>([
   'AdvanceNonceAccount',
   'SetComputeUnitLimit',
@@ -31,14 +17,7 @@ const ENVELOPE_INSTRUCTIONS: ReadonlySet<InstructionType> = new Set<InstructionT
   'Memo',
 ]);
 
-/**
- * The core instruction sequence of each Kiln operation, in order.
- *
- * `stake` is three instructions because StakeProgram.createAccount expands into a System
- * Program account creation followed by the Stake Program initialize, before the delegate.
- * `split-stake` carries the new account's rent-exempt reserve, so a System Program creation
- * may precede the split.
- */
+/** `stake` is three instructions because createAccount expands into create + initialize. */
 const KILN_OPERATIONS: ReadonlyArray<{ operation: string; sequences: ReadonlyArray<InstructionType[]> }> = [
   {
     operation: 'stake',
@@ -64,10 +43,8 @@ export const classifySolanaTransaction = (instructions: DecodedInstruction[]): T
     return unrecognized('This transaction contains no instructions.');
   }
 
-  // Any instruction minitel could not decode, or one from a program outside the four Kiln
-  // uses, means the transaction does something we cannot account for. Fail closed before
-  // looking at shape at all — an unreadable instruction next to a valid stake is still
-  // unreadable.
+  // Fail closed before matching shape: an unreadable instruction next to a valid stake is
+  // still unreadable.
   const undecodable = instructions.find((i) => i.type === 'unknown' || i.type === 'error');
   if (undecodable) {
     return unrecognized(

--- a/apps/solana/src/kiln-operations.ts
+++ b/apps/solana/src/kiln-operations.ts
@@ -4,7 +4,7 @@ import { type DecodedInstruction, getProgramKeyFromId, type InstructionType } fr
 /**
  * The Solana operations Kiln crafts, and the instructions each one is made of.
  *
- * Source of truth is the crafting service (services/sof/tx, SolController + SolService):
+ * Source of truth is Kiln's transaction-crafting API:
  * `/sol/transaction/{stake,deactivate-stake,withdraw-stake,split-stake,merge-stakes}`.
  * Every one of those is built as a nonce advance followed by a single Stake Program action,
  * so the shape of a genuine Kiln transaction is narrow and checkable.

--- a/apps/solana/src/solana-adapter.tsx
+++ b/apps/solana/src/solana-adapter.tsx
@@ -1,6 +1,7 @@
 import { type ProtocolAdapter, SOL } from '@protocols/shared';
 import { Transaction } from '@solana/web3.js';
 import { Summary } from '@/components/Summary';
+import { classifySolanaTransaction } from '@/kiln-operations';
 import { convertToMessage, looksLikeMessage, type MessageLike, type ParseSolTxResult, parseSolTx } from '@/parser';
 import type { DecodedInstruction } from '@/types';
 import { base64ToHex, isBase64, isHex, sha256 } from '@/utils';
@@ -59,6 +60,8 @@ export const solanaAdapter: ProtocolAdapter<ParseSolTxResult> = {
   computeHash: computeSolanaHash,
 
   renderSummary: (data) => <Summary instructions={data.instructions} />,
+
+  classifyTransaction: (data) => classifySolanaTransaction(data.instructions),
 
   generateWarnings: (data) => {
     return data.instructions

--- a/apps/solana/tsconfig.json
+++ b/apps/solana/tsconfig.json
@@ -8,5 +8,6 @@
       "@protocols/shared": ["../../packages/shared/src"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }

--- a/apps/sui/src/kiln-operations.test.ts
+++ b/apps/sui/src/kiln-operations.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from 'bun:test';
+import { Transaction } from '@mysten/sui/transactions';
+import { classifySuiTransaction } from '@/kiln-operations';
+import { parseSuiTx } from '@/parser';
+
+/**
+ * Each case is built with the same library Kiln's crafting service uses, serialized to BCS and
+ * run back through the real parser, so a change on either side shows up here.
+ */
+
+const sender = `0x${'11'.repeat(32)}`;
+const validator = `0x${'22'.repeat(32)}`;
+const recipient = `0x${'44'.repeat(32)}`;
+const stakeId = `0x${'55'.repeat(32)}`;
+const otherStakeId = `0x${'66'.repeat(32)}`;
+const SUI_SYSTEM_STATE = `0x${'0'.repeat(63)}5`;
+
+/** The shared system-state object, spelled out so the transaction builds without a client. */
+const systemState = (tx: Transaction) =>
+  tx.sharedObjectRef({ objectId: SUI_SYSTEM_STATE, initialSharedVersion: '1', mutable: true });
+
+/** An owned object reference, likewise fully specified. */
+const owned = (tx: Transaction, objectId: string) =>
+  tx.objectRef({ objectId, version: '1', digest: '11111111111111111111111111111111' });
+
+const build = async (fill: (tx: Transaction) => void) => {
+  const tx = new Transaction();
+  tx.setSender(sender);
+  tx.setGasPrice(1000n);
+  tx.setGasBudget(10_000_000n);
+  tx.setGasPayment([{ objectId: `0x${'33'.repeat(32)}`, version: '1', digest: '11111111111111111111111111111111' }]);
+  fill(tx);
+  return Buffer.from(await tx.build()).toString('hex');
+};
+
+const classify = async (fill: (tx: Transaction) => void) => classifySuiTransaction(await parseSuiTx(await build(fill)));
+
+describe('Kiln Sui operations are recognized', () => {
+  test('stake — split off the gas coin, then request_add_stake', async () => {
+    const verdict = await classify((tx) => {
+      const [coin] = tx.splitCoins(tx.gas, [tx.pure.u64(1_000_000_000n)]);
+      tx.moveCall({
+        target: '0x3::sui_system::request_add_stake',
+        arguments: [systemState(tx), coin, tx.pure.address(validator)],
+      });
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'stake' });
+  });
+
+  test('unstake — request_withdraw_stake', async () => {
+    const verdict = await classify((tx) => {
+      tx.moveCall({
+        target: '0x3::sui_system::request_withdraw_stake',
+        arguments: [systemState(tx), owned(tx, stakeId)],
+      });
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'unstake' });
+  });
+
+  test('split-stake — split_staked_sui', async () => {
+    const verdict = await classify((tx) => {
+      tx.moveCall({
+        target: '0x3::staking_pool::split_staked_sui',
+        arguments: [owned(tx, stakeId), tx.pure.u64(500_000_000n)],
+      });
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'split-stake' });
+  });
+
+  test('merge — join_staked_sui', async () => {
+    const verdict = await classify((tx) => {
+      tx.moveCall({
+        target: '0x3::staking_pool::join_staked_sui',
+        arguments: [owned(tx, stakeId), owned(tx, otherStakeId)],
+      });
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'merge' });
+  });
+
+  test('send — split off the gas coin, then transfer it', async () => {
+    const verdict = await classify((tx) => {
+      const [coin] = tx.splitCoins(tx.gas, [tx.pure.u64(1_000_000n)]);
+      tx.transferObjects([coin], tx.pure.address(recipient));
+    });
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'send' });
+  });
+});
+
+describe('Non-Kiln Sui transactions are rejected', () => {
+  test('a call into a package that is not the Sui framework', async () => {
+    const verdict = await classify((tx) => {
+      tx.moveCall({
+        target: `0x${'ab'.repeat(32)}::drainer::take_everything`,
+        arguments: [owned(tx, stakeId)],
+      });
+    });
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('not part of the Sui framework') });
+  });
+
+  test('a framework call Kiln never makes', async () => {
+    const verdict = await classify((tx) => {
+      tx.moveCall({
+        target: '0x3::sui_system::request_add_validator',
+        arguments: [systemState(tx)],
+      });
+    });
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('request_add_validator') });
+  });
+
+  test('a transfer smuggled in after a valid unstake', async () => {
+    const verdict = await classify((tx) => {
+      tx.moveCall({
+        target: '0x3::sui_system::request_withdraw_stake',
+        arguments: [systemState(tx), owned(tx, stakeId)],
+      });
+      const [coin] = tx.splitCoins(tx.gas, [tx.pure.u64(1_000_000n)]);
+      tx.transferObjects([coin], tx.pure.address(recipient));
+    });
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('which is not how Kiln crafts it') });
+  });
+
+  test('two staking calls in one transaction', async () => {
+    const verdict = await classify((tx) => {
+      tx.moveCall({
+        target: '0x3::sui_system::request_withdraw_stake',
+        arguments: [systemState(tx), owned(tx, stakeId)],
+      });
+      tx.moveCall({
+        target: '0x3::staking_pool::join_staked_sui',
+        arguments: [owned(tx, otherStakeId), owned(tx, stakeId)],
+      });
+    });
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('2 Move calls') });
+  });
+
+  test('transferring a staked object outright, with no call at all', async () => {
+    const verdict = await classify((tx) => {
+      tx.transferObjects([owned(tx, stakeId)], tx.pure.address(recipient));
+    });
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('calls nothing') });
+  });
+});

--- a/apps/sui/src/kiln-operations.test.ts
+++ b/apps/sui/src/kiln-operations.test.ts
@@ -3,10 +3,7 @@ import { Transaction } from '@mysten/sui/transactions';
 import { classifySuiTransaction } from '@/kiln-operations';
 import { parseSuiTx } from '@/parser';
 
-/**
- * Each case is built with the same library Kiln's crafting service uses, serialized to BCS and
- * run back through the real parser, so a change on either side shows up here.
- */
+/** Each case is built with the same library Kiln uses and run back through the real parser. */
 
 const sender = `0x${'11'.repeat(32)}`;
 const validator = `0x${'22'.repeat(32)}`;

--- a/apps/sui/src/kiln-operations.ts
+++ b/apps/sui/src/kiln-operations.ts
@@ -2,21 +2,9 @@ import type { Transaction } from '@mysten/sui/transactions';
 import { recognized, type TransactionVerdict, unrecognized } from '@protocols/shared';
 
 /**
- * The Sui operations Kiln crafts, and the commands each one is made of.
- *
- * Source of truth is Kiln's transaction-crafting API, which the public Kiln Connect spec
- * exposes as `/sui/transaction/{stake,unstake,split-stake,merge,send}`. Every one is a short,
- * fixed command sequence:
- *
- * - stake — split the amount off the gas coin, then request_add_stake
- * - unstake — request_withdraw_stake
- * - split-stake — split_staked_sui
- * - merge — join_staked_sui
- * - send — split the amount off the gas coin, then transfer it
- *
- * Matching is on that sequence and on the Move function called, not on the validator staked
- * with or the recipient sent to. Those are the user's own choices and live outside minitel; the
- * decoded summary below the verdict is where they are checked.
+ * Kiln's Sui routes are short fixed command sequences: stake splits the amount off the gas coin
+ * then calls request_add_stake, send splits then transfers, and the rest are a single Move call.
+ * Matched on that sequence and the function, not on the validator or recipient.
  */
 
 type TransactionData = ReturnType<typeof Transaction.prototype.getData>;
@@ -33,7 +21,7 @@ const OPERATION_BY_MOVE_CALL: Record<string, string> = {
   'staking_pool::join_staked_sui': 'merge',
 };
 
-/** A readable name for a command, used only to explain a rejection. */
+/** Used only to explain a rejection. */
 const describe = (command: Command): string => {
   if (command.$kind === 'MoveCall' && command.MoveCall) {
     const { package: pkg, module, function: fn } = command.MoveCall;
@@ -58,8 +46,7 @@ export const classifySuiTransaction = (transaction: TransactionData): Transactio
 
   const kinds = commands.map((command) => command.$kind);
 
-  // send is the one operation with no Move call at all: split the amount off the gas coin and
-  // hand it over. It is a genuine Kiln route, so it is matched before the staking calls.
+  // send is the one route with no Move call at all, so it is matched before the staking calls.
   if (kinds.length === 2 && kinds[0] === 'SplitCoins' && kinds[1] === 'TransferObjects') {
     return recognized('send');
   }
@@ -90,8 +77,7 @@ export const classifySuiTransaction = (transaction: TransactionData): Transactio
     return unrecognized(`This transaction calls ${key}, which is not a function Kiln operations use.`);
   }
 
-  // Staking splits the amount off the gas coin first; the other three take existing objects and
-  // add nothing. Any further command alongside the call is something we did not craft.
+  // Staking splits off the gas coin first; the others add nothing around the call.
   const expected = operation === 'stake' ? ['SplitCoins', 'MoveCall'] : ['MoveCall'];
   const matches = kinds.length === expected.length && kinds.every((kind, index) => kind === expected[index]);
 

--- a/apps/sui/src/kiln-operations.ts
+++ b/apps/sui/src/kiln-operations.ts
@@ -1,0 +1,105 @@
+import type { Transaction } from '@mysten/sui/transactions';
+import { recognized, type TransactionVerdict, unrecognized } from '@protocols/shared';
+
+/**
+ * The Sui operations Kiln crafts, and the commands each one is made of.
+ *
+ * Source of truth is Kiln's transaction-crafting API, which the public Kiln Connect spec
+ * exposes as `/sui/transaction/{stake,unstake,split-stake,merge,send}`. Every one is a short,
+ * fixed command sequence:
+ *
+ * - stake — split the amount off the gas coin, then request_add_stake
+ * - unstake — request_withdraw_stake
+ * - split-stake — split_staked_sui
+ * - merge — join_staked_sui
+ * - send — split the amount off the gas coin, then transfer it
+ *
+ * Matching is on that sequence and on the Move function called, not on the validator staked
+ * with or the recipient sent to. Those are the user's own choices and live outside minitel; the
+ * decoded summary below the verdict is where they are checked.
+ */
+
+type TransactionData = ReturnType<typeof Transaction.prototype.getData>;
+type Command = TransactionData['commands'][number];
+
+/** The Sui framework package that owns every staking entrypoint. */
+const SUI_FRAMEWORK_PACKAGE = '0x0000000000000000000000000000000000000000000000000000000000000003';
+
+/** `module::function` → the Kiln operation, for calls into the framework package above. */
+const OPERATION_BY_MOVE_CALL: Record<string, string> = {
+  'sui_system::request_add_stake': 'stake',
+  'sui_system::request_withdraw_stake': 'unstake',
+  'staking_pool::split_staked_sui': 'split-stake',
+  'staking_pool::join_staked_sui': 'merge',
+};
+
+/** A readable name for a command, used only to explain a rejection. */
+const describe = (command: Command): string => {
+  if (command.$kind === 'MoveCall' && command.MoveCall) {
+    const { package: pkg, module, function: fn } = command.MoveCall;
+    return `a call to ${pkg === SUI_FRAMEWORK_PACKAGE ? '' : `${pkg}::`}${module}::${fn}`;
+  }
+  return `a ${command.$kind} command`;
+};
+
+const moveCallKey = (command: Command): string | null => {
+  if (command.$kind !== 'MoveCall' || !command.MoveCall) return null;
+  const { package: pkg, module, function: fn } = command.MoveCall;
+  if (pkg !== SUI_FRAMEWORK_PACKAGE) return null;
+  return `${module}::${fn}`;
+};
+
+export const classifySuiTransaction = (transaction: TransactionData): TransactionVerdict => {
+  const commands = transaction?.commands ?? [];
+
+  if (commands.length === 0) {
+    return unrecognized('This transaction contains no commands.');
+  }
+
+  const kinds = commands.map((command) => command.$kind);
+
+  // send is the one operation with no Move call at all: split the amount off the gas coin and
+  // hand it over. It is a genuine Kiln route, so it is matched before the staking calls.
+  if (kinds.length === 2 && kinds[0] === 'SplitCoins' && kinds[1] === 'TransferObjects') {
+    return recognized('send');
+  }
+
+  const moveCalls = commands.filter((command) => command.$kind === 'MoveCall');
+
+  if (moveCalls.length === 0) {
+    return unrecognized(
+      `This transaction runs ${commands.map(describe).join(', ')} and calls nothing, so it is not a Kiln operation.`,
+    );
+  }
+
+  if (moveCalls.length > 1) {
+    return unrecognized(
+      `This transaction makes ${moveCalls.length} Move calls (${moveCalls.map(describe).join(', ')}). Kiln operations on Sui make one.`,
+    );
+  }
+
+  const key = moveCallKey(moveCalls[0]);
+
+  if (!key) {
+    return unrecognized(`This transaction makes ${describe(moveCalls[0])}, which is not part of the Sui framework.`);
+  }
+
+  const operation = OPERATION_BY_MOVE_CALL[key];
+
+  if (!operation) {
+    return unrecognized(`This transaction calls ${key}, which is not a function Kiln operations use.`);
+  }
+
+  // Staking splits the amount off the gas coin first; the other three take existing objects and
+  // add nothing. Any further command alongside the call is something we did not craft.
+  const expected = operation === 'stake' ? ['SplitCoins', 'MoveCall'] : ['MoveCall'];
+  const matches = kinds.length === expected.length && kinds.every((kind, index) => kind === expected[index]);
+
+  if (!matches) {
+    return unrecognized(
+      `This transaction wraps ${key} in ${commands.map(describe).join(', ')}, which is not how Kiln crafts it.`,
+    );
+  }
+
+  return recognized(operation);
+};

--- a/apps/sui/src/sui-adapter.ts
+++ b/apps/sui/src/sui-adapter.ts
@@ -1,7 +1,8 @@
 import type { Transaction } from '@mysten/sui/transactions';
 import { fromBase64, fromHex } from '@mysten/sui/utils';
 import { blake2b } from '@noble/hashes/blake2.js';
-import { type ProtocolAdapter, pendingAllowlist, SUI } from '@protocols/shared';
+import { type ProtocolAdapter, SUI } from '@protocols/shared';
+import { classifySuiTransaction } from '@/kiln-operations';
 import { parseSuiTx } from '@/parser';
 
 const isHex = (input: string): boolean => {
@@ -63,6 +64,5 @@ export const suiAdapter: ProtocolAdapter<ReturnType<typeof Transaction.prototype
   validateInput: isValidSuiInput,
   parseTransaction: parseSuiTx,
   computeHash: computeSuiHash,
-  // Kiln crafts stake, unstake, split-stake, merge and send on Sui — allowlist not written yet.
-  classifyTransaction: pendingAllowlist,
+  classifyTransaction: classifySuiTransaction,
 };

--- a/apps/sui/src/sui-adapter.ts
+++ b/apps/sui/src/sui-adapter.ts
@@ -1,7 +1,7 @@
 import type { Transaction } from '@mysten/sui/transactions';
 import { fromBase64, fromHex } from '@mysten/sui/utils';
 import { blake2b } from '@noble/hashes/blake2.js';
-import { type ProtocolAdapter, SUI } from '@protocols/shared';
+import { type ProtocolAdapter, pendingAllowlist, SUI } from '@protocols/shared';
 import { parseSuiTx } from '@/parser';
 
 const isHex = (input: string): boolean => {
@@ -63,4 +63,6 @@ export const suiAdapter: ProtocolAdapter<ReturnType<typeof Transaction.prototype
   validateInput: isValidSuiInput,
   parseTransaction: parseSuiTx,
   computeHash: computeSuiHash,
+  // Kiln crafts stake, unstake, split-stake, merge and send on Sui — allowlist not written yet.
+  classifyTransaction: pendingAllowlist,
 };

--- a/apps/sui/tsconfig.json
+++ b/apps/sui/tsconfig.json
@@ -9,5 +9,6 @@
       "@protocols/cosmos-shared": ["../../packages/cosmos-shared/src"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }

--- a/apps/ton/src/kiln-operations.test.ts
+++ b/apps/ton/src/kiln-operations.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from 'bun:test';
+import TonWeb from 'tonweb';
+import { classifyTonTransaction } from '@/kiln-operations';
+import { parseTonTx } from '@/parser';
+
+/**
+ * Each case is a real BOC, built with the same library Kiln's crafting service uses and run
+ * back through the real parser, so a change on either side shows up here.
+ */
+
+const pool = 'EQAREREREREREREREREREREREREREREREREREREREREREeYT';
+const vestingContract = 'EQAiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIp3C';
+
+const VESTING_SEND = 0xa7733acd;
+const VESTING_ADD_WHITELIST = 0x7258a69b;
+const SINGLE_NOMINATOR_WITHDRAW = 0x1000;
+const WHALES_STAKE_WITHDRAW = 3665837821;
+
+type Cell = InstanceType<typeof TonWeb.boc.Cell>;
+
+const coins = (n: string) => new TonWeb.utils.BN(n);
+
+/** An internal message to `dest`, carrying `payload` as its body. */
+const internalMessage = (dest: string, amount: string, payload?: Cell): Cell =>
+  TonWeb.Contract.createCommonMsgInfo(
+    TonWeb.Contract.createInternalMessageHeader(dest, coins(amount)),
+    undefined,
+    payload,
+  );
+
+/** Wrap messages in the wallet body and the external message the parser expects. */
+const forge = async (messages: Cell[]): Promise<string> => {
+  const body = new TonWeb.boc.Cell();
+  body.bits.writeUint(698983191, 32);
+  body.bits.writeUint(1800000000, 32);
+  body.bits.writeUint(1, 32);
+  body.bits.writeUint(0, 8);
+  body.bits.writeUint(3, 8);
+  for (const message of messages) body.refs.push(message);
+
+  const external = TonWeb.Contract.createCommonMsgInfo(
+    TonWeb.Contract.createExternalMessageHeader(pool),
+    undefined,
+    body,
+  );
+  return Buffer.from(await external.toBoc(false)).toString('hex');
+};
+
+const classify = async (messages: Cell[]) => classifyTonTransaction(await parseTonTx(await forge(messages)));
+
+const depositComment = (): Cell => {
+  const cell = new TonWeb.boc.Cell();
+  cell.bits.writeUint(0, 32);
+  cell.bits.writeString('Deposit');
+  return cell;
+};
+
+const singleNominatorWithdraw = (): Cell => {
+  const cell = new TonWeb.boc.Cell();
+  cell.bits.writeUint(SINGLE_NOMINATOR_WITHDRAW, 32);
+  cell.bits.writeUint(0, 64);
+  cell.bits.writeCoins(coins('5000000000'));
+  return cell;
+};
+
+const whalesWithdraw = (): Cell => {
+  const cell = new TonWeb.boc.Cell();
+  cell.bits.writeUint(WHALES_STAKE_WITHDRAW, 32);
+  cell.bits.writeUint(0, 64);
+  cell.bits.writeCoins(coins('100000000'));
+  cell.bits.writeCoins(coins('5000000000'));
+  return cell;
+};
+
+const addWhitelist = (): Cell => {
+  const cell = new TonWeb.boc.Cell();
+  cell.bits.writeUint(VESTING_ADD_WHITELIST, 32);
+  cell.bits.writeUint(0, 64);
+  cell.bits.writeAddress(new TonWeb.utils.Address(pool));
+  return cell;
+};
+
+/** The vesting contract forwarding a message on the owner's behalf. */
+const vestingSend = (inner: Cell): Cell => {
+  const cell = new TonWeb.boc.Cell();
+  cell.bits.writeUint(VESTING_SEND, 32);
+  cell.bits.writeUint(0, 64);
+  cell.bits.writeUint(3, 8);
+  cell.refs.push(internalMessage(pool, '5000000000', inner));
+  return cell;
+};
+
+describe('Kiln Gram operations are recognized', () => {
+  test('stake-pool — a whales deposit carries a Deposit comment', async () => {
+    const verdict = await classify([internalMessage(pool, '5000000000', depositComment())]);
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'stake-pool' });
+  });
+
+  test('unstake-pool — the whales nominator withdraw opcode', async () => {
+    const verdict = await classify([internalMessage(pool, '100000000', whalesWithdraw())]);
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'unstake-pool' });
+  });
+
+  test('unstake-single-nomination-pool — the pool withdraw opcode', async () => {
+    const verdict = await classify([internalMessage(pool, '100000000', singleNominatorWithdraw())]);
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'unstake-single-nomination-pool' });
+  });
+
+  test('whitelist-vesting-contract — the add_whitelist opcode', async () => {
+    const verdict = await classify([internalMessage(vestingContract, '100000000', addWhitelist())]);
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'whitelist-vesting-contract' });
+  });
+
+  test('an unstake routed through a vesting contract reads the same as a direct one', async () => {
+    const verdict = await classify([internalMessage(vestingContract, '100000000', vestingSend(whalesWithdraw()))]);
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'unstake-pool' });
+  });
+});
+
+describe('Non-Kiln Gram transactions are rejected', () => {
+  test('a message carrying an opcode Kiln never sends', async () => {
+    const cell = new TonWeb.boc.Cell();
+    cell.bits.writeUint(0xdeadbeef, 32);
+    cell.bits.writeUint(0, 64);
+    const verdict = await classify([internalMessage(pool, '5000000000', cell)]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('opcode') });
+  });
+
+  test('a text comment that is not a deposit', async () => {
+    const cell = new TonWeb.boc.Cell();
+    cell.bits.writeUint(0, 32);
+    cell.bits.writeString('Withdraw everything to me');
+    const verdict = await classify([internalMessage(pool, '5000000000', cell)]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('Withdraw everything to me') });
+  });
+
+  test('a second message alongside a valid deposit', async () => {
+    const verdict = await classify([
+      internalMessage(pool, '5000000000', depositComment()),
+      internalMessage(vestingContract, '9000000000'),
+    ]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('sends 2 messages') });
+  });
+});
+
+describe('The transfer minitel cannot decide', () => {
+  test('a bare transfer is unverified — a pool deposit and a drain look identical here', async () => {
+    const verdict = await classify([internalMessage(pool, '5000000000')]);
+
+    expect(verdict.status).toBe('unverified');
+    const reason = 'reason' in verdict ? verdict.reason : '';
+    expect(reason).toContain('single-nominator pool');
+    expect(reason).toContain(pool);
+  });
+});

--- a/apps/ton/src/kiln-operations.test.ts
+++ b/apps/ton/src/kiln-operations.test.ts
@@ -3,10 +3,7 @@ import TonWeb from 'tonweb';
 import { classifyTonTransaction } from '@/kiln-operations';
 import { parseTonTx } from '@/parser';
 
-/**
- * Each case is a real BOC, built with the same library Kiln's crafting service uses and run
- * back through the real parser, so a change on either side shows up here.
- */
+/** Each case is a real BOC, built the way Kiln builds them and run through the real parser. */
 
 const pool = 'EQAREREREREREREREREREREREREREREREREREREREREREeYT';
 const vestingContract = 'EQAiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIp3C';

--- a/apps/ton/src/kiln-operations.ts
+++ b/apps/ton/src/kiln-operations.ts
@@ -1,0 +1,101 @@
+import { recognized, type TransactionVerdict, unrecognized, unverified } from '@protocols/shared';
+
+/**
+ * The Gram (ex TON) operations Kiln crafts, and the message each one sends.
+ *
+ * Source of truth is Kiln's transaction-crafting API, which the public Kiln Connect spec
+ * exposes as `/gram/transaction/{stake-single-nomination-pool,unstake-single-nomination-pool,
+ * stake-pool,unstake-pool,whitelist-vesting-contract}`.
+ *
+ * Every one sends a single internal message, identified by the opcode at the head of its body:
+ *
+ * - unstake from a single-nominator pool — the pool's withdraw opcode
+ * - unstake from a whales pool — the nominator contract's stake_withdraw opcode
+ * - stake into a whales pool — a text comment reading "Deposit"
+ * - whitelist a vesting contract — the vesting contract's add_whitelist opcode
+ *
+ * Each of these can also be sent *through* a vesting contract, which wraps the real message in
+ * a vesting `send`. The wrapper is unwrapped and the message inside is classified on its own
+ * terms, so a vesting-routed unstake reads the same as a direct one.
+ *
+ * Staking into a single-nominator pool is the exception, and the reason this file returns
+ * `unverified` for one case: on this chain that deposit is nothing but a transfer of TON to the
+ * pool address, with no opcode and no comment to match on. It is indistinguishable from sending
+ * TON to any other address, and the only thing separating the two is whether the destination is
+ * a Kiln pool — which lives in Kiln's configuration and is not knowable here.
+ */
+
+type ParsedBody = {
+  op_code_name?: string;
+  op_code?: number;
+  params?: { out_msg?: { body?: ParsedBody } };
+};
+
+type ParsedMessage = {
+  header?: { dest?: { bouncable?: string } | null; grams?: string };
+  body?: ParsedBody;
+};
+
+/** The parser returns internal messages keyed by index, or just a wallet body if there are none. */
+type ParsedTonTransaction = Record<string, { message?: ParsedMessage } | unknown>;
+
+const OPERATION_BY_OPCODE_NAME: Record<string, string> = {
+  vesting_contract_single_nominator_pool_withdraw: 'unstake-single-nomination-pool',
+  whales_nominator_contract_stake_withdraw: 'unstake-pool',
+  vesting_contract_add_whitelist: 'whitelist-vesting-contract',
+};
+
+/** The text comment a whales-pool deposit carries in place of an opcode. */
+const WHALES_DEPOSIT_COMMENT = 'Deposit';
+
+const isMessageEntry = (entry: unknown): entry is { message: ParsedMessage } =>
+  typeof entry === 'object' && entry !== null && 'message' in entry;
+
+/**
+ * A vesting contract forwards on the owner's behalf, so the operation being authorised is the
+ * one inside the wrapper rather than the wrapper itself.
+ */
+const unwrapVestingSend = (body: ParsedBody | undefined): ParsedBody | undefined =>
+  body?.op_code_name === 'vesting_contract_send' ? body.params?.out_msg?.body : body;
+
+export const classifyTonTransaction = (transaction: ParsedTonTransaction): TransactionVerdict => {
+  const messages = Object.values(transaction ?? {}).filter(isMessageEntry);
+
+  if (messages.length === 0) {
+    return unrecognized('This transaction sends no message, so there is no operation to check.');
+  }
+
+  // Kiln sends one message per transaction. A wallet can carry up to four, and the summary
+  // renders them all, but a second message is not something we crafted.
+  if (messages.length > 1) {
+    return unrecognized(`This transaction sends ${messages.length} messages. Kiln operations on this chain send one.`);
+  }
+
+  const body = unwrapVestingSend(messages[0].message?.body);
+  const opCodeName = body?.op_code_name;
+
+  if (opCodeName && OPERATION_BY_OPCODE_NAME[opCodeName]) {
+    return recognized(OPERATION_BY_OPCODE_NAME[opCodeName]);
+  }
+
+  if (opCodeName === WHALES_DEPOSIT_COMMENT) {
+    return recognized('stake-pool');
+  }
+
+  // No opcode and no comment: a bare transfer. That is exactly what a single-nominator pool
+  // deposit looks like, and exactly what sending TON to an attacker looks like too.
+  if (!opCodeName || opCodeName === 'unknown') {
+    if (body?.op_code !== undefined) {
+      return unrecognized(
+        `This transaction sends a message with opcode ${body.op_code}, which is not one Kiln operations use.`,
+      );
+    }
+
+    const destination = messages[0].message?.header?.dest?.bouncable;
+    return unverified(
+      `This is the shape of a deposit into a single-nominator pool — a plain transfer carrying no instruction — but that is also the shape of sending your funds anywhere else. Check that ${destination ?? 'the destination below'} is the Kiln pool you meant to stake with.`,
+    );
+  }
+
+  return unrecognized(`This transaction sends a "${opCodeName}" message, which is not one Kiln operations use.`);
+};

--- a/apps/ton/src/kiln-operations.ts
+++ b/apps/ton/src/kiln-operations.ts
@@ -1,28 +1,12 @@
 import { recognized, type TransactionVerdict, unrecognized, unverified } from '@protocols/shared';
 
 /**
- * The Gram (ex TON) operations Kiln crafts, and the message each one sends.
+ * Kiln's Gram routes each send one internal message, identified by the opcode at the head of
+ * its body — or, for a whales deposit, a "Deposit" text comment. Any of them may be routed
+ * through a vesting contract, which wraps the real message in a vesting send.
  *
- * Source of truth is Kiln's transaction-crafting API, which the public Kiln Connect spec
- * exposes as `/gram/transaction/{stake-single-nomination-pool,unstake-single-nomination-pool,
- * stake-pool,unstake-pool,whitelist-vesting-contract}`.
- *
- * Every one sends a single internal message, identified by the opcode at the head of its body:
- *
- * - unstake from a single-nominator pool — the pool's withdraw opcode
- * - unstake from a whales pool — the nominator contract's stake_withdraw opcode
- * - stake into a whales pool — a text comment reading "Deposit"
- * - whitelist a vesting contract — the vesting contract's add_whitelist opcode
- *
- * Each of these can also be sent *through* a vesting contract, which wraps the real message in
- * a vesting `send`. The wrapper is unwrapped and the message inside is classified on its own
- * terms, so a vesting-routed unstake reads the same as a direct one.
- *
- * Staking into a single-nominator pool is the exception, and the reason this file returns
- * `unverified` for one case: on this chain that deposit is nothing but a transfer of TON to the
- * pool address, with no opcode and no comment to match on. It is indistinguishable from sending
- * TON to any other address, and the only thing separating the two is whether the destination is
- * a Kiln pool — which lives in Kiln's configuration and is not knowable here.
+ * Staking into a single-nominator pool is the exception: it is a bare transfer to the pool,
+ * indistinguishable from sending funds anywhere else, so it can only be unverified.
  */
 
 type ParsedBody = {
@@ -36,7 +20,7 @@ type ParsedMessage = {
   body?: ParsedBody;
 };
 
-/** The parser returns internal messages keyed by index, or just a wallet body if there are none. */
+/** Internal messages keyed by index, or just a wallet body if there are none. */
 type ParsedTonTransaction = Record<string, { message?: ParsedMessage } | unknown>;
 
 const OPERATION_BY_OPCODE_NAME: Record<string, string> = {
@@ -45,16 +29,13 @@ const OPERATION_BY_OPCODE_NAME: Record<string, string> = {
   vesting_contract_add_whitelist: 'whitelist-vesting-contract',
 };
 
-/** The text comment a whales-pool deposit carries in place of an opcode. */
+/** A whales-pool deposit carries this comment in place of an opcode. */
 const WHALES_DEPOSIT_COMMENT = 'Deposit';
 
 const isMessageEntry = (entry: unknown): entry is { message: ParsedMessage } =>
   typeof entry === 'object' && entry !== null && 'message' in entry;
 
-/**
- * A vesting contract forwards on the owner's behalf, so the operation being authorised is the
- * one inside the wrapper rather than the wrapper itself.
- */
+/** A vesting contract forwards on the owner's behalf, so the real operation is inside. */
 const unwrapVestingSend = (body: ParsedBody | undefined): ParsedBody | undefined =>
   body?.op_code_name === 'vesting_contract_send' ? body.params?.out_msg?.body : body;
 
@@ -65,8 +46,7 @@ export const classifyTonTransaction = (transaction: ParsedTonTransaction): Trans
     return unrecognized('This transaction sends no message, so there is no operation to check.');
   }
 
-  // Kiln sends one message per transaction. A wallet can carry up to four, and the summary
-  // renders them all, but a second message is not something we crafted.
+  // A wallet can carry up to four, but Kiln sends one.
   if (messages.length > 1) {
     return unrecognized(`This transaction sends ${messages.length} messages. Kiln operations on this chain send one.`);
   }
@@ -82,8 +62,7 @@ export const classifyTonTransaction = (transaction: ParsedTonTransaction): Trans
     return recognized('stake-pool');
   }
 
-  // No opcode and no comment: a bare transfer. That is exactly what a single-nominator pool
-  // deposit looks like, and exactly what sending TON to an attacker looks like too.
+  // No opcode and no comment: a bare transfer, which is both a pool deposit and a drain.
   if (!opCodeName || opCodeName === 'unknown') {
     if (body?.op_code !== undefined) {
       return unrecognized(

--- a/apps/ton/src/ton-adapter.ts
+++ b/apps/ton/src/ton-adapter.ts
@@ -1,4 +1,4 @@
-import { type ProtocolAdapter, TON } from '@protocols/shared';
+import { type ProtocolAdapter, pendingAllowlist, TON } from '@protocols/shared';
 import { Cell } from '@ton/core';
 import { parseTonTx } from '@/parser';
 
@@ -43,4 +43,7 @@ export const tonAdapter: ProtocolAdapter<any> = {
   validateInput: isValidTonInput,
   parseTransaction: parseTonTx,
   computeHash: computeTonHash,
+  // Kiln crafts the nomination-pool and whales-pool stake/unstake pairs plus
+  // whitelist-vesting-contract here — allowlist not written yet.
+  classifyTransaction: pendingAllowlist,
 };

--- a/apps/ton/src/ton-adapter.ts
+++ b/apps/ton/src/ton-adapter.ts
@@ -1,5 +1,6 @@
-import { type ProtocolAdapter, pendingAllowlist, TON } from '@protocols/shared';
+import { type ProtocolAdapter, TON } from '@protocols/shared';
 import { Cell } from '@ton/core';
+import { classifyTonTransaction } from '@/kiln-operations';
 import { parseTonTx } from '@/parser';
 
 const isValidTonInput = (rawTx: string): boolean => {
@@ -43,7 +44,5 @@ export const tonAdapter: ProtocolAdapter<any> = {
   validateInput: isValidTonInput,
   parseTransaction: parseTonTx,
   computeHash: computeTonHash,
-  // Kiln crafts the nomination-pool and whales-pool stake/unstake pairs plus
-  // whitelist-vesting-contract here — allowlist not written yet.
-  classifyTransaction: pendingAllowlist,
+  classifyTransaction: classifyTonTransaction,
 };

--- a/apps/ton/tsconfig.json
+++ b/apps/ton/tsconfig.json
@@ -9,5 +9,6 @@
       "@protocols/cosmos-shared": ["../../packages/cosmos-shared/src"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }

--- a/apps/trx/src/kiln-operations.test.ts
+++ b/apps/trx/src/kiln-operations.test.ts
@@ -4,10 +4,7 @@ import 'tronweb';
 import { classifyTrxTransaction } from '@/kiln-operations';
 import { parseTrxTx } from '@/parser';
 
-/**
- * Minimal protobuf writers, so each case is a real serialized Tron transaction run through the
- * actual parser rather than a hand-written object.
- */
+/** Minimal protobuf writers, so each case is a real transaction run through the real parser. */
 const varint = (n: number): number[] => {
   const out: number[] = [];
   let value = n;

--- a/apps/trx/src/kiln-operations.test.ts
+++ b/apps/trx/src/kiln-operations.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'bun:test';
+// tronweb installs the protobuf runtime the parser reads off globalThis.
+import 'tronweb';
+import { classifyTrxTransaction } from '@/kiln-operations';
+import { parseTrxTx } from '@/parser';
+
+/**
+ * Minimal protobuf writers, so each case is a real serialized Tron transaction run through the
+ * actual parser rather than a hand-written object.
+ */
+const varint = (n: number): number[] => {
+  const out: number[] = [];
+  let value = n;
+  do {
+    let byte = value & 0x7f;
+    value >>>= 7;
+    if (value) byte |= 0x80;
+    out.push(byte);
+  } while (value);
+  return out;
+};
+const lenField = (field: number, payload: number[]): number[] => [
+  (field << 3) | 2,
+  ...varint(payload.length),
+  ...payload,
+];
+const varField = (field: number, n: number): number[] => [(field << 3) | 0, ...varint(n)];
+const utf8 = (s: string): number[] => Array.from(Buffer.from(s, 'utf8'));
+
+const owner = [0x41, ...Array(20).fill(0xab)];
+const witness = [0x41, ...Array(20).fill(0xcd)];
+
+/** `Transaction.Contract`: a type tag plus the operation packed into a protobuf Any. */
+const contract = (typeName: string, body: number[], typeTag = 0): number[] => [
+  ...varField(1, typeTag),
+  ...lenField(2, [...lenField(1, utf8(`type.googleapis.com/${typeName}`)), ...lenField(2, body)]),
+];
+
+/** `Transaction.raw` — field 11 is the repeated contract list. */
+const rawTx = (contracts: number[][]): string =>
+  Buffer.from([
+    ...lenField(1, [0xb1, 0xf9]),
+    ...lenField(4, Array(8).fill(0x11)),
+    ...varField(8, 1700000000000),
+    ...contracts.flatMap((c) => lenField(11, c)),
+    ...varField(14, 1699999000000),
+  ]).toString('hex');
+
+const classify = async (contracts: number[][]) => classifyTrxTransaction(await parseTrxTx(rawTx(contracts)));
+
+const freezeV2 = () =>
+  contract('protocol.FreezeBalanceV2Contract', [...lenField(1, owner), ...varField(2, 1_000_000), ...varField(3, 1)]);
+const unfreezeV2 = () =>
+  contract('protocol.UnfreezeBalanceV2Contract', [...lenField(1, owner), ...varField(2, 1_000_000), ...varField(3, 1)]);
+const cancelUnfreeze = () => contract('protocol.CancelAllUnfreezeV2Contract', [...lenField(1, owner)]);
+const withdrawExpire = () => contract('protocol.WithdrawExpireUnfreezeContract', [...lenField(1, owner)]);
+const withdrawBalance = () => contract('protocol.WithdrawBalanceContract', [...lenField(1, owner)]);
+const voteWitness = () =>
+  contract('protocol.VoteWitnessContract', [
+    ...lenField(1, owner),
+    ...lenField(2, [...lenField(1, witness), ...varField(2, 100)]),
+  ]);
+
+describe('Kiln Tron operations are recognized', () => {
+  test('stake — FreezeBalanceV2', async () => {
+    expect(await classify([freezeV2()])).toMatchObject({ status: 'recognized', operation: 'stake' });
+  });
+
+  test('unstake — UnfreezeBalanceV2', async () => {
+    expect(await classify([unfreezeV2()])).toMatchObject({ status: 'recognized', operation: 'unstake' });
+  });
+
+  test('cancel-unstake — CancelAllUnfreezeV2', async () => {
+    expect(await classify([cancelUnfreeze()])).toMatchObject({ status: 'recognized', operation: 'cancel-unstake' });
+  });
+
+  test('withdraw-unstaked — WithdrawExpireUnfreeze', async () => {
+    expect(await classify([withdrawExpire()])).toMatchObject({
+      status: 'recognized',
+      operation: 'withdraw-unstaked',
+    });
+  });
+
+  test('vote — VoteWitness', async () => {
+    expect(await classify([voteWitness()])).toMatchObject({ status: 'recognized', operation: 'vote' });
+  });
+
+  test('withdraw-rewards — WithdrawBalance', async () => {
+    expect(await classify([withdrawBalance()])).toMatchObject({
+      status: 'recognized',
+      operation: 'withdraw-rewards',
+    });
+  });
+});
+
+describe('Non-Kiln Tron transactions are rejected', () => {
+  test('a plain TRX transfer', async () => {
+    const transfer = contract('protocol.TransferContract', [
+      ...lenField(1, owner),
+      ...lenField(2, witness),
+      ...varField(3, 1_000_000),
+    ]);
+    const verdict = await classify([transfer]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('TransferContract') });
+  });
+
+  test('a smart contract call', async () => {
+    const trigger = contract('protocol.TriggerSmartContract', [...lenField(1, owner), ...lenField(2, witness)]);
+    const verdict = await classify([trigger]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('TriggerSmartContract') });
+  });
+
+  test('an account permission update, which can hand over the account', async () => {
+    const permission = contract('protocol.AccountPermissionUpdateContract', [...lenField(1, owner)]);
+    const verdict = await classify([permission]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('AccountPermissionUpdateContract') });
+  });
+
+  test('a transfer smuggled behind a valid freeze, where only the freeze is rendered', async () => {
+    const transfer = contract('protocol.TransferContract', [
+      ...lenField(1, owner),
+      ...lenField(2, witness),
+      ...varField(3, 1_000_000),
+    ]);
+    const verdict = await classify([freezeV2(), transfer]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('bundles 2 contracts') });
+  });
+});

--- a/apps/trx/src/kiln-operations.ts
+++ b/apps/trx/src/kiln-operations.ts
@@ -2,16 +2,8 @@ import { recognized, type TransactionVerdict, unrecognized } from '@protocols/sh
 import type { TrxTransaction } from '@/parser';
 
 /**
- * The Tron operations Kiln crafts, one contract type each.
- *
- * Source of truth is Kiln's transaction-crafting API, which the public Kiln Connect spec
- * exposes as `/trx/transaction/{stake,unstake,cancel-unstake,withdraw-unstaked,vote,
- * withdraw-rewards}`. Tron models each of these as a distinct contract type, so the mapping is
- * one to one and there is nothing to match on beyond the type itself.
- *
- * Matching is on the contract type, not on the witness being voted for. The validator list
- * lives in Kiln's configuration and changes without minitel knowing; the decoded summary below
- * the verdict is where the user checks which witness their votes go to.
+ * Tron models each Kiln route as its own contract type, so the mapping is one to one. Matched
+ * on that type, not on the witness voted for, which is Kiln configuration.
  */
 const OPERATION_BY_CONTRACT: Record<string, string> = {
   'protocol.FreezeBalanceV2Contract': 'stake',
@@ -32,9 +24,7 @@ export const classifyTrxTransaction = (transaction: TrxTransaction): Transaction
     return unrecognized('This transaction carries no contract.');
   }
 
-  // The decoder only ever renders the first contract, so a second one would be invisible in the
-  // summary below. Every Kiln operation is a single contract, and Tron itself has never
-  // supported more, but rejecting the case is what keeps the summary honest about what it shows.
+  // The decoder renders only the first contract, so a second would be invisible below.
   if (contracts.length > 1) {
     return unrecognized(
       `This transaction bundles ${contracts.length} contracts, and only the first is shown below. Kiln operations carry exactly one.`,

--- a/apps/trx/src/kiln-operations.ts
+++ b/apps/trx/src/kiln-operations.ts
@@ -1,0 +1,52 @@
+import { recognized, type TransactionVerdict, unrecognized } from '@protocols/shared';
+import type { TrxTransaction } from '@/parser';
+
+/**
+ * The Tron operations Kiln crafts, one contract type each.
+ *
+ * Source of truth is Kiln's transaction-crafting API, which the public Kiln Connect spec
+ * exposes as `/trx/transaction/{stake,unstake,cancel-unstake,withdraw-unstaked,vote,
+ * withdraw-rewards}`. Tron models each of these as a distinct contract type, so the mapping is
+ * one to one and there is nothing to match on beyond the type itself.
+ *
+ * Matching is on the contract type, not on the witness being voted for. The validator list
+ * lives in Kiln's configuration and changes without minitel knowing; the decoded summary below
+ * the verdict is where the user checks which witness their votes go to.
+ */
+const OPERATION_BY_CONTRACT: Record<string, string> = {
+  'protocol.FreezeBalanceV2Contract': 'stake',
+  'protocol.UnfreezeBalanceV2Contract': 'unstake',
+  'protocol.CancelAllUnfreezeV2Contract': 'cancel-unstake',
+  'protocol.WithdrawExpireUnfreezeContract': 'withdraw-unstaked',
+  'protocol.VoteWitnessContract': 'vote',
+  'protocol.WithdrawBalanceContract': 'withdraw-rewards',
+};
+
+/** `type.googleapis.com/protocol.VoteWitnessContract` → `protocol.VoteWitnessContract`. */
+const contractType = (typeUrl: string): string => typeUrl.split('/').pop() ?? typeUrl;
+
+export const classifyTrxTransaction = (transaction: TrxTransaction): TransactionVerdict => {
+  const contracts = transaction?.raw?.contractList ?? [];
+
+  if (contracts.length === 0) {
+    return unrecognized('This transaction carries no contract.');
+  }
+
+  // The decoder only ever renders the first contract, so a second one would be invisible in the
+  // summary below. Every Kiln operation is a single contract, and Tron itself has never
+  // supported more, but rejecting the case is what keeps the summary honest about what it shows.
+  if (contracts.length > 1) {
+    return unrecognized(
+      `This transaction bundles ${contracts.length} contracts, and only the first is shown below. Kiln operations carry exactly one.`,
+    );
+  }
+
+  const type = contractType(contracts[0]?.parameter?.typeUrl ?? '');
+  const operation = OPERATION_BY_CONTRACT[type];
+
+  if (!operation) {
+    return unrecognized(`This transaction is a ${type || 'nameless contract'}, which is not an operation Kiln crafts.`);
+  }
+
+  return recognized(operation);
+};

--- a/apps/trx/src/parser.ts
+++ b/apps/trx/src/parser.ts
@@ -4,8 +4,22 @@ import { TrxProtobuf } from '@/protos';
 const TronWeb = tronweb.TronWeb;
 const addressUtils = TronWeb.address;
 
+/** One entry of `Transaction.raw.contract`, as protobuf.js renders it. */
+export type TrxContract = {
+  type: number;
+  parameter: { typeUrl: string; value: string };
+};
+
+export type TrxTransaction = {
+  decodedValue: Record<string, unknown>;
+  raw: {
+    contractList: TrxContract[];
+    [key: string]: unknown;
+  };
+};
+
 export class TrxParser {
-  public serializedToPb(tx_serialized: string): unknown {
+  public serializedToPb(tx_serialized: string): TrxTransaction {
     // @ts-expect-error
     const txData = globalThis.proto.Transaction.raw.deserializeBinary(Buffer.from(tx_serialized, 'hex'));
     const txDataObj = txData.toObject();
@@ -19,7 +33,7 @@ export class TrxParser {
       raw: { ...txDataObj },
     };
 
-    return enhancedDecoded;
+    return enhancedDecoded as TrxTransaction;
   }
 
   private formatAddress(hexBuffer: Buffer): string | null {
@@ -154,7 +168,7 @@ export class TrxParser {
 
 const trxParser = new TrxParser();
 
-export const parseTrxTx = async (tx_serialized: string) => {
+export const parseTrxTx = async (tx_serialized: string): Promise<TrxTransaction> => {
   try {
     const pbTx = trxParser.serializedToPb(tx_serialized);
     return pbTx;

--- a/apps/trx/src/trx-adapter.ts
+++ b/apps/trx/src/trx-adapter.ts
@@ -1,5 +1,6 @@
-import { type ProtocolAdapter, pendingAllowlist, TRX } from '@protocols/shared';
-import { parseTrxTx } from '@/parser';
+import { type ProtocolAdapter, TRX } from '@protocols/shared';
+import { classifyTrxTransaction } from '@/kiln-operations';
+import { parseTrxTx, type TrxTransaction } from '@/parser';
 
 const isValidTrxInput = (rawTx: string): boolean => {
   const input = rawTx.trim();
@@ -20,7 +21,7 @@ const computeTrxHash = async (rawTx: string): Promise<string> => {
   }
 };
 
-export const trxAdapter: ProtocolAdapter<unknown> = {
+export const trxAdapter: ProtocolAdapter<TrxTransaction> = {
   protocol: TRX,
   name: 'trx',
   displayName: 'Tron',
@@ -28,7 +29,5 @@ export const trxAdapter: ProtocolAdapter<unknown> = {
   validateInput: isValidTrxInput,
   parseTransaction: parseTrxTx,
   computeHash: computeTrxHash,
-  // Kiln crafts stake, unstake, cancel-unstake, withdraw-unstaked, vote and withdraw-rewards
-  // on Tron — allowlist not written yet.
-  classifyTransaction: pendingAllowlist,
+  classifyTransaction: classifyTrxTransaction,
 };

--- a/apps/trx/src/trx-adapter.ts
+++ b/apps/trx/src/trx-adapter.ts
@@ -1,4 +1,4 @@
-import { type ProtocolAdapter, TRX } from '@protocols/shared';
+import { type ProtocolAdapter, pendingAllowlist, TRX } from '@protocols/shared';
 import { parseTrxTx } from '@/parser';
 
 const isValidTrxInput = (rawTx: string): boolean => {
@@ -28,4 +28,7 @@ export const trxAdapter: ProtocolAdapter<unknown> = {
   validateInput: isValidTrxInput,
   parseTransaction: parseTrxTx,
   computeHash: computeTrxHash,
+  // Kiln crafts stake, unstake, cancel-unstake, withdraw-unstaked, vote and withdraw-rewards
+  // on Tron — allowlist not written yet.
+  classifyTransaction: pendingAllowlist,
 };

--- a/apps/trx/tsconfig.json
+++ b/apps/trx/tsconfig.json
@@ -9,5 +9,6 @@
       "@protocols/cosmos-shared": ["../../packages/cosmos-shared/src"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }

--- a/apps/xtz/src/kiln-operations.test.ts
+++ b/apps/xtz/src/kiln-operations.test.ts
@@ -3,10 +3,7 @@ import { localForger } from '@taquito/local-forging';
 import { classifyXtzTransaction } from '@/kiln-operations';
 import { parseXtzTx } from '@/parser';
 
-/**
- * Each case is forged with Taquito and run back through the real parser, so the shapes here are
- * the shapes minitel sees rather than hand-written objects.
- */
+/** Each case is forged with Taquito and run back through the real parser. */
 
 const wallet = 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb';
 const baker = 'tz1Kf25fX1VdmYGSEzwFy1wNmkbSEZ2V83sY';

--- a/apps/xtz/src/kiln-operations.test.ts
+++ b/apps/xtz/src/kiln-operations.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from 'bun:test';
+import { localForger } from '@taquito/local-forging';
+import { classifyXtzTransaction } from '@/kiln-operations';
+import { parseXtzTx } from '@/parser';
+
+/**
+ * Each case is forged with Taquito and run back through the real parser, so the shapes here are
+ * the shapes minitel sees rather than hand-written objects.
+ */
+
+const wallet = 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb';
+const baker = 'tz1Kf25fX1VdmYGSEzwFy1wNmkbSEZ2V83sY';
+const branch = 'BLockGenesisGenesisGenesisGenesisGenesisf79b5d1CoW2';
+
+const common = { fee: '1000', counter: '1', gas_limit: '10000', storage_limit: '100' };
+
+const forge = async (contents: unknown[]) => localForger.forge({ branch, contents } as never);
+
+const classify = async (contents: unknown[]) => classifyXtzTransaction(await parseXtzTx(await forge(contents)));
+
+const selfCall = (entrypoint: string, amount = '1000000') => ({
+  kind: 'transaction',
+  source: wallet,
+  destination: wallet,
+  amount,
+  ...common,
+  parameters: { entrypoint, value: { prim: 'Unit' } },
+});
+
+const reveal = () => ({
+  kind: 'reveal',
+  source: wallet,
+  public_key: 'edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav',
+  ...common,
+});
+
+describe('Kiln Tezos operations are recognized', () => {
+  test('stake', async () => {
+    expect(await classify([selfCall('stake')])).toMatchObject({ status: 'recognized', operation: 'stake' });
+  });
+
+  test('unstake', async () => {
+    expect(await classify([selfCall('unstake')])).toMatchObject({ status: 'recognized', operation: 'unstake' });
+  });
+
+  test('finalize-unstake', async () => {
+    expect(await classify([selfCall('finalize_unstake', '0')])).toMatchObject({
+      status: 'recognized',
+      operation: 'finalize-unstake',
+    });
+  });
+
+  test('delegate — a baker is set', async () => {
+    const verdict = await classify([{ kind: 'delegation', source: wallet, delegate: baker, ...common }]);
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'delegate' });
+  });
+
+  test('undelegate — the delegate is cleared', async () => {
+    const verdict = await classify([{ kind: 'delegation', source: wallet, ...common }]);
+
+    expect(verdict).toMatchObject({ status: 'recognized', operation: 'undelegate' });
+  });
+
+  test('a reveal preceding a stake is treated as envelope', async () => {
+    expect(await classify([reveal(), selfCall('stake')])).toMatchObject({
+      status: 'recognized',
+      operation: 'stake',
+    });
+  });
+});
+
+describe('Non-Kiln Tezos transactions are rejected', () => {
+  test('a plain tez transfer', async () => {
+    const verdict = await classify([
+      { kind: 'transaction', source: wallet, destination: baker, amount: '1000000', ...common },
+    ]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('plain tez transfer') });
+  });
+
+  test('a call to some other entrypoint', async () => {
+    const verdict = await classify([
+      {
+        kind: 'transaction',
+        source: wallet,
+        destination: wallet,
+        amount: '0',
+        ...common,
+        parameters: { entrypoint: 'set_delegate_parameters', value: { prim: 'Unit' } },
+      },
+    ]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('set_delegate_parameters entrypoint') });
+  });
+
+  test('a stake entrypoint aimed at someone else', async () => {
+    const verdict = await classify([
+      {
+        kind: 'transaction',
+        source: wallet,
+        destination: baker,
+        amount: '1000000',
+        ...common,
+        parameters: { entrypoint: 'stake', value: { prim: 'Unit' } },
+      },
+    ]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('not on your own account') });
+  });
+
+  test('a transfer smuggled alongside a valid stake', async () => {
+    const verdict = await classify([
+      selfCall('stake'),
+      { kind: 'transaction', source: wallet, destination: baker, amount: '1000000', ...common, counter: '2' },
+    ]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('bundles 2 operations') });
+  });
+
+  test('a reveal on its own', async () => {
+    const verdict = await classify([reveal()]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('only reveals a public key') });
+  });
+});

--- a/apps/xtz/src/kiln-operations.ts
+++ b/apps/xtz/src/kiln-operations.ts
@@ -2,22 +2,9 @@ import { recognized, type TransactionVerdict, unrecognized } from '@protocols/sh
 import type { ForgeParams } from '@taquito/local-forging';
 
 /**
- * The Tezos operations Kiln crafts, and the operation each one forges.
- *
- * Source of truth is Kiln's transaction-crafting API, which the public Kiln Connect spec
- * exposes as `/xtz/transaction/{stake,unstake,finalize-unstake,delegate,undelegate}`:
- *
- * - stake, unstake and finalize-unstake are self-transactions — source and destination are the
- *   same account — calling the protocol entrypoint of the same name.
- * - delegate sets a baker, undelegate clears it. Both are delegation operations, told apart by
- *   whether a delegate is present.
- *
- * Matching is on the operation kind and entrypoint, not on the baker being delegated to. The
- * baker address is chosen per customer and lives outside minitel; the decoded summary below the
- * verdict is where the user checks it.
- *
- * A reveal may legitimately precede any of these the first time an account transacts, so it is
- * treated as envelope rather than as a second operation.
+ * Kiln's Tezos routes: stake, unstake and finalize-unstake are self-transactions calling the
+ * entrypoint of the same name; delegate and undelegate are delegations, told apart by whether
+ * a delegate is set. Matched on kind and entrypoint, not on the baker.
  */
 
 type OperationContent = ForgeParams['contents'][number];
@@ -29,10 +16,7 @@ const OPERATION_BY_ENTRYPOINT: Record<string, string> = {
   finalize_unstake: 'finalize-unstake',
 };
 
-/**
- * Revealing the public key is a one-off the protocol requires before an account's first
- * operation, and Kiln's crafting prepends it when needed. It moves no funds.
- */
+/** A one-off before an account's first operation, prepended by Kiln. It moves no funds. */
 const isReveal = (content: OperationContent): boolean => content.kind === 'reveal';
 
 const describe = (content: OperationContent): string => {
@@ -91,8 +75,8 @@ export const classifyXtzTransaction = (transaction: ForgeParams): TransactionVer
     return unrecognized(`This transaction calls the ${entrypoint} entrypoint, which Kiln operations do not use.`);
   }
 
-  // Staking on Tezos moves funds within your own account, so the destination is the source.
-  // A stake entrypoint aimed elsewhere is a contract call wearing a familiar name.
+  // Staking moves funds within your own account, so an entrypoint aimed elsewhere is a
+  // contract call wearing a familiar name.
   if (transactionOp.source && transactionOp.destination && transactionOp.source !== transactionOp.destination) {
     return unrecognized(
       `This transaction calls the ${entrypoint} entrypoint on ${transactionOp.destination}, not on your own account. Kiln stakes to your own account.`,

--- a/apps/xtz/src/kiln-operations.ts
+++ b/apps/xtz/src/kiln-operations.ts
@@ -1,0 +1,103 @@
+import { recognized, type TransactionVerdict, unrecognized } from '@protocols/shared';
+import type { ForgeParams } from '@taquito/local-forging';
+
+/**
+ * The Tezos operations Kiln crafts, and the operation each one forges.
+ *
+ * Source of truth is Kiln's transaction-crafting API, which the public Kiln Connect spec
+ * exposes as `/xtz/transaction/{stake,unstake,finalize-unstake,delegate,undelegate}`:
+ *
+ * - stake, unstake and finalize-unstake are self-transactions — source and destination are the
+ *   same account — calling the protocol entrypoint of the same name.
+ * - delegate sets a baker, undelegate clears it. Both are delegation operations, told apart by
+ *   whether a delegate is present.
+ *
+ * Matching is on the operation kind and entrypoint, not on the baker being delegated to. The
+ * baker address is chosen per customer and lives outside minitel; the decoded summary below the
+ * verdict is where the user checks it.
+ *
+ * A reveal may legitimately precede any of these the first time an account transacts, so it is
+ * treated as envelope rather than as a second operation.
+ */
+
+type OperationContent = ForgeParams['contents'][number];
+
+/** Entrypoint → operation, for the three self-transaction forms. */
+const OPERATION_BY_ENTRYPOINT: Record<string, string> = {
+  stake: 'stake',
+  unstake: 'unstake',
+  finalize_unstake: 'finalize-unstake',
+};
+
+/**
+ * Revealing the public key is a one-off the protocol requires before an account's first
+ * operation, and Kiln's crafting prepends it when needed. It moves no funds.
+ */
+const isReveal = (content: OperationContent): boolean => content.kind === 'reveal';
+
+const describe = (content: OperationContent): string => {
+  const { kind } = content;
+  if (kind === 'transaction') {
+    const entrypoint = (content as { parameters?: { entrypoint?: string } }).parameters?.entrypoint;
+    return entrypoint ? `a call to the ${entrypoint} entrypoint` : 'a plain tez transfer';
+  }
+  return `a ${kind} operation`;
+};
+
+export const classifyXtzTransaction = (transaction: ForgeParams): TransactionVerdict => {
+  const contents = transaction?.contents ?? [];
+  const operations = contents.filter((content) => !isReveal(content));
+
+  if (contents.length === 0) {
+    return unrecognized('This transaction contains no operations.');
+  }
+
+  if (operations.length === 0) {
+    return unrecognized('This transaction only reveals a public key and carries no Kiln operation.');
+  }
+
+  if (operations.length > 1) {
+    return unrecognized(
+      `This transaction bundles ${operations.length} operations (${operations.map(describe).join(', ')}). Kiln operations on Tezos carry one.`,
+    );
+  }
+
+  const operation = operations[0];
+
+  if (operation.kind === 'delegation') {
+    // Taquito omits the field entirely when the delegation is being cleared.
+    const delegate = (operation as { delegate?: string }).delegate;
+    return recognized(delegate ? 'delegate' : 'undelegate');
+  }
+
+  if (operation.kind !== 'transaction') {
+    return unrecognized(`This transaction is ${describe(operation)}, which is not an operation Kiln crafts.`);
+  }
+
+  const transactionOp = operation as {
+    source?: string;
+    destination?: string;
+    parameters?: { entrypoint?: string };
+  };
+  const entrypoint = transactionOp.parameters?.entrypoint;
+
+  if (!entrypoint) {
+    return unrecognized('This transaction is a plain tez transfer, not a Kiln staking operation.');
+  }
+
+  const matched = OPERATION_BY_ENTRYPOINT[entrypoint];
+
+  if (!matched) {
+    return unrecognized(`This transaction calls the ${entrypoint} entrypoint, which Kiln operations do not use.`);
+  }
+
+  // Staking on Tezos moves funds within your own account, so the destination is the source.
+  // A stake entrypoint aimed elsewhere is a contract call wearing a familiar name.
+  if (transactionOp.source && transactionOp.destination && transactionOp.source !== transactionOp.destination) {
+    return unrecognized(
+      `This transaction calls the ${entrypoint} entrypoint on ${transactionOp.destination}, not on your own account. Kiln stakes to your own account.`,
+    );
+  }
+
+  return recognized(matched);
+};

--- a/apps/xtz/src/xtz-adapter.ts
+++ b/apps/xtz/src/xtz-adapter.ts
@@ -1,6 +1,7 @@
 import { blake2b } from '@noble/hashes/blake2.js';
-import { type ProtocolAdapter, pendingAllowlist, XTZ } from '@protocols/shared';
+import { type ProtocolAdapter, XTZ } from '@protocols/shared';
 import type { ForgeParams } from '@taquito/local-forging';
+import { classifyXtzTransaction } from '@/kiln-operations';
 import { parseXtzTx } from '@/parser';
 
 const isValidXtzInput = (rawTx: string): boolean => {
@@ -31,7 +32,5 @@ export const xtzAdapter: ProtocolAdapter<ForgeParams> = {
   validateInput: isValidXtzInput,
   parseTransaction: parseXtzTx,
   computeHash: computeXtzHash,
-  // Kiln crafts stake, unstake, delegate, undelegate and finalize-unstake on Tezos —
-  // allowlist not written yet.
-  classifyTransaction: pendingAllowlist,
+  classifyTransaction: classifyXtzTransaction,
 };

--- a/apps/xtz/src/xtz-adapter.ts
+++ b/apps/xtz/src/xtz-adapter.ts
@@ -1,5 +1,5 @@
 import { blake2b } from '@noble/hashes/blake2.js';
-import { type ProtocolAdapter, XTZ } from '@protocols/shared';
+import { type ProtocolAdapter, pendingAllowlist, XTZ } from '@protocols/shared';
 import type { ForgeParams } from '@taquito/local-forging';
 import { parseXtzTx } from '@/parser';
 
@@ -31,4 +31,7 @@ export const xtzAdapter: ProtocolAdapter<ForgeParams> = {
   validateInput: isValidXtzInput,
   parseTransaction: parseXtzTx,
   computeHash: computeXtzHash,
+  // Kiln crafts stake, unstake, delegate, undelegate and finalize-unstake on Tezos —
+  // allowlist not written yet.
+  classifyTransaction: pendingAllowlist,
 };

--- a/apps/xtz/tsconfig.json
+++ b/apps/xtz/tsconfig.json
@@ -9,5 +9,6 @@
       "@protocols/cosmos-shared": ["../../packages/cosmos-shared/src"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }

--- a/packages/cosmos-shared/src/CosmosTransactionSummary.tsx
+++ b/packages/cosmos-shared/src/CosmosTransactionSummary.tsx
@@ -29,6 +29,8 @@ const getMessageLabel = (message: CosmosMessage): string => {
       return 'Authz Exec';
     case 'authzRevoke':
       return 'Authz Revoke';
+    case 'ibcTransfer':
+      return 'IBC Transfer';
     case 'unsupported':
       return 'Unsupported';
     default:
@@ -68,6 +70,8 @@ const getMessageAccount = (message: CosmosMessage): string => {
       return message.granter;
     case 'authzExec':
       return message.grantee;
+    case 'ibcTransfer':
+      return message.sender;
     default:
       return '-';
   }
@@ -81,6 +85,8 @@ const getMessageAmount = (message: CosmosMessage): string => {
       return formatCoin(message.amount);
     case 'send':
       return formatCoins(message.amount);
+    case 'ibcTransfer':
+      return formatCoin(message.token);
     default:
       return '-';
   }
@@ -98,11 +104,15 @@ const getMessageDetails = (message: CosmosMessage): string => {
     case 'send':
       return `To: ${message.toAddress}`;
     case 'authzGrant':
-      return `Grantee: ${message.grantee} (${message.authorizationType})`;
+      return message.stakeAuthorization
+        ? `Grantee: ${message.grantee} — may ${message.stakeAuthorization.authorizationType} to ${message.stakeAuthorization.allowList.join(', ') || 'any validator'}`
+        : `Grantee: ${message.grantee} (${message.authorizationType})`;
     case 'authzExec':
       return `Nested: ${message.innerTypeUrls.join(', ') || 'none'}`;
     case 'authzRevoke':
       return `Grantee: ${message.grantee} (${message.msgTypeUrl})`;
+    case 'ibcTransfer':
+      return `To: ${message.receiver} over ${message.sourcePort}/${message.sourceChannel}`;
     case 'unsupported':
       return message.typeUrl || 'unknown type';
     default:

--- a/packages/cosmos-shared/src/cosmos-adapter.tsx
+++ b/packages/cosmos-shared/src/cosmos-adapter.tsx
@@ -1,4 +1,4 @@
-import type { Protocol, ProtocolAdapter } from '@protocols/shared';
+import { type Protocol, type ProtocolAdapter, pendingAllowlist } from '@protocols/shared';
 import { CosmosTransactionSummary } from './CosmosTransactionSummary';
 import { type CosmosMessage, type CosmosTransaction, parseCosmosTx } from './parser';
 
@@ -65,6 +65,11 @@ export const createCosmosAdapter = ({
     parseTransaction: async (rawTx) => parseCosmosTx(rawTx),
     computeHash: computeCosmosHash,
     renderSummary: (data) => <CosmosTransactionSummary transaction={data} />,
+    // The Cosmos parser already fails closed on unknown typeUrls, so the pieces for a real
+    // allowlist are here. It is left pending deliberately: the operation set differs per chain
+    // (send exists on cro/fet/sei only, restake-rewards on atom/tia/osmo/cro/fet), so it needs
+    // to be driven per protocol rather than guessed in the shared factory.
+    classifyTransaction: pendingAllowlist,
     generateWarnings: (data) => data.messages.flatMap(warningsForMessage).map((message) => ({ message })),
   };
 };

--- a/packages/cosmos-shared/src/cosmos-adapter.tsx
+++ b/packages/cosmos-shared/src/cosmos-adapter.tsx
@@ -1,5 +1,6 @@
-import { type Protocol, type ProtocolAdapter, pendingAllowlist } from '@protocols/shared';
+import type { Protocol, ProtocolAdapter } from '@protocols/shared';
 import { CosmosTransactionSummary } from './CosmosTransactionSummary';
+import { type CosmosChainName, classifyCosmosTransaction } from './kiln-operations';
 import { type CosmosMessage, type CosmosTransaction, parseCosmosTx } from './parser';
 
 const isValidCosmosInput = (rawTx: string): boolean => {
@@ -42,6 +43,10 @@ const warningsForMessage = (message: CosmosMessage): string[] => {
       ];
     case 'authzRevoke':
       return [`⚠️ Authz revoke detected for ${message.grantee} (${message.msgTypeUrl})`];
+    case 'ibcTransfer':
+      return [
+        `⚠️ IBC transfer detected: ${message.token?.amount ?? '?'} ${message.token?.denom ?? '?'} to ${message.receiver} over ${message.sourceChannel}`,
+      ];
     default:
       return [];
   }
@@ -52,7 +57,9 @@ export const createCosmosAdapter = ({
   displayName,
   protocol,
 }: {
-  name: string;
+  // Typed as the chain union so a new Cosmos app cannot be added without declaring which
+  // operations Kiln crafts for it.
+  name: CosmosChainName;
   displayName: string;
   protocol: Protocol;
 }): ProtocolAdapter<CosmosTransaction> => {
@@ -65,11 +72,7 @@ export const createCosmosAdapter = ({
     parseTransaction: async (rawTx) => parseCosmosTx(rawTx),
     computeHash: computeCosmosHash,
     renderSummary: (data) => <CosmosTransactionSummary transaction={data} />,
-    // The Cosmos parser already fails closed on unknown typeUrls, so the pieces for a real
-    // allowlist are here. It is left pending deliberately: the operation set differs per chain
-    // (send exists on cro/fet/sei only, restake-rewards on atom/tia/osmo/cro/fet), so it needs
-    // to be driven per protocol rather than guessed in the shared factory.
-    classifyTransaction: pendingAllowlist,
+    classifyTransaction: (data) => classifyCosmosTransaction(name, data),
     generateWarnings: (data) => data.messages.flatMap(warningsForMessage).map((message) => ({ message })),
   };
 };

--- a/packages/cosmos-shared/src/index.ts
+++ b/packages/cosmos-shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from './CosmosTransactionSummary';
 export * from './cosmos-adapter';
+export * from './kiln-operations';
 export * from './parser';

--- a/packages/cosmos-shared/src/kiln-operations.test.ts
+++ b/packages/cosmos-shared/src/kiln-operations.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, test } from 'bun:test';
+import { MsgGrant, MsgRevoke } from 'cosmjs-types/cosmos/authz/v1beta1/tx';
+import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx';
+import { MsgWithdrawDelegatorReward } from 'cosmjs-types/cosmos/distribution/v1beta1/tx';
+import { AuthorizationType, StakeAuthorization } from 'cosmjs-types/cosmos/staking/v1beta1/authz';
+import { MsgBeginRedelegate, MsgDelegate, MsgUndelegate } from 'cosmjs-types/cosmos/staking/v1beta1/tx';
+import { AuthInfo, TxBody, TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
+import type { Any } from 'cosmjs-types/google/protobuf/any';
+import { MsgTransfer } from 'cosmjs-types/ibc/applications/transfer/v1/tx';
+import { type CosmosChainName, classifyCosmosTransaction } from './kiln-operations';
+import { parseCosmosTx } from './parser';
+
+/**
+ * The messages below mirror how services/sof/tx (CosmosMessages + CosmosServiceV2) builds each
+ * operation, so a change on either side shows up here rather than in production.
+ */
+
+const delegator = 'cosmos1delegator';
+const validator = 'cosmosvaloper1kiln';
+const grantee = 'cosmos1kilnrestaker';
+
+const toHex = (bytes: Uint8Array): string =>
+  Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+
+const encodeTx = (messages: Any[]): string => {
+  const bodyBytes = TxBody.encode(TxBody.fromPartial({ messages })).finish();
+  const authInfoBytes = AuthInfo.encode(AuthInfo.fromPartial({})).finish();
+  return toHex(TxRaw.encode(TxRaw.fromPartial({ bodyBytes, authInfoBytes, signatures: [] })).finish());
+};
+
+const classify = async (chain: CosmosChainName, messages: Any[]) =>
+  classifyCosmosTransaction(chain, await parseCosmosTx(encodeTx(messages)));
+
+const delegateMsg = (): Any => ({
+  typeUrl: '/cosmos.staking.v1beta1.MsgDelegate',
+  value: MsgDelegate.encode(
+    MsgDelegate.fromPartial({
+      delegatorAddress: delegator,
+      validatorAddress: validator,
+      amount: { denom: 'uatom', amount: '1000000' },
+    }),
+  ).finish(),
+});
+
+const undelegateMsg = (): Any => ({
+  typeUrl: '/cosmos.staking.v1beta1.MsgUndelegate',
+  value: MsgUndelegate.encode(
+    MsgUndelegate.fromPartial({
+      delegatorAddress: delegator,
+      validatorAddress: validator,
+      amount: { denom: 'uatom', amount: '1000000' },
+    }),
+  ).finish(),
+});
+
+const redelegateMsg = (): Any => ({
+  typeUrl: '/cosmos.staking.v1beta1.MsgBeginRedelegate',
+  value: MsgBeginRedelegate.encode(
+    MsgBeginRedelegate.fromPartial({
+      delegatorAddress: delegator,
+      validatorSrcAddress: validator,
+      validatorDstAddress: 'cosmosvaloper1other',
+      amount: { denom: 'uatom', amount: '1000000' },
+    }),
+  ).finish(),
+});
+
+const withdrawRewardsMsg = (): Any => ({
+  typeUrl: '/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward',
+  value: MsgWithdrawDelegatorReward.encode(
+    MsgWithdrawDelegatorReward.fromPartial({ delegatorAddress: delegator, validatorAddress: validator }),
+  ).finish(),
+});
+
+const sendMsg = (toAddress = 'cosmos1recipient'): Any => ({
+  typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+  value: MsgSend.encode(
+    MsgSend.fromPartial({
+      fromAddress: delegator,
+      toAddress,
+      amount: [{ denom: 'uatom', amount: '1000000' }],
+    }),
+  ).finish(),
+});
+
+/** The MsgGrant CosmosMessages.getRestakeRewardsMsg builds. */
+const restakeGrantMsg = (authorizationType = AuthorizationType.AUTHORIZATION_TYPE_DELEGATE): Any => ({
+  typeUrl: '/cosmos.authz.v1beta1.MsgGrant',
+  value: MsgGrant.encode(
+    MsgGrant.fromPartial({
+      granter: delegator,
+      grantee,
+      grant: {
+        expiration: { seconds: 1n },
+        authorization: {
+          typeUrl: '/cosmos.staking.v1beta1.StakeAuthorization',
+          value: StakeAuthorization.encode(
+            StakeAuthorization.fromPartial({
+              allowList: { address: [validator] },
+              authorizationType,
+            }),
+          ).finish(),
+        },
+      },
+    }),
+  ).finish(),
+});
+
+const revokeRestakeMsg = (msgTypeUrl = '/cosmos.staking.v1beta1.MsgDelegate'): Any => ({
+  typeUrl: '/cosmos.authz.v1beta1.MsgRevoke',
+  value: MsgRevoke.encode(MsgRevoke.fromPartial({ granter: delegator, grantee, msgTypeUrl })).finish(),
+});
+
+/** The MsgTransfer dYdX's noble-ibc-transfer route builds. */
+const ibcTransferMsg = (): Any => ({
+  typeUrl: '/ibc.applications.transfer.v1.MsgTransfer',
+  value: MsgTransfer.encode(
+    MsgTransfer.fromPartial({
+      sourcePort: 'transfer',
+      sourceChannel: 'channel-0',
+      token: { denom: 'ibc/8E27BA2D', amount: '1000000' },
+      sender: 'dydx1delegator',
+      receiver: 'noble1delegator',
+    }),
+  ).finish(),
+});
+
+describe('Kiln Cosmos operations are recognized', () => {
+  test('stake', async () => {
+    expect(await classify('atom', [delegateMsg()])).toMatchObject({ status: 'recognized', operation: 'stake' });
+  });
+
+  test('unstake', async () => {
+    expect(await classify('atom', [undelegateMsg()])).toMatchObject({ status: 'recognized', operation: 'unstake' });
+  });
+
+  test('redelegate', async () => {
+    expect(await classify('atom', [redelegateMsg()])).toMatchObject({
+      status: 'recognized',
+      operation: 'redelegate',
+    });
+  });
+
+  test('withdraw-rewards', async () => {
+    expect(await classify('atom', [withdrawRewardsMsg()])).toMatchObject({
+      status: 'recognized',
+      operation: 'withdraw-rewards',
+    });
+  });
+
+  test('restake-rewards', async () => {
+    expect(await classify('atom', [restakeGrantMsg()])).toMatchObject({
+      status: 'recognized',
+      operation: 'restake-rewards',
+    });
+  });
+
+  test('revoke-restake-rewards', async () => {
+    expect(await classify('atom', [revokeRestakeMsg()])).toMatchObject({
+      status: 'recognized',
+      operation: 'revoke-restake-rewards',
+    });
+  });
+
+  test('stake with restaking turned on — MsgDelegate followed by the grant', async () => {
+    expect(await classify('atom', [delegateMsg(), restakeGrantMsg()])).toMatchObject({
+      status: 'recognized',
+      operation: 'stake-with-restake-rewards',
+    });
+  });
+
+  test('send, on a chain that exposes it', async () => {
+    expect(await classify('cronos', [sendMsg()])).toMatchObject({ status: 'recognized', operation: 'send' });
+  });
+
+  test("dYdX's IBC transfer of USDC rewards to Noble", async () => {
+    expect(await classify('dydx', [ibcTransferMsg()])).toMatchObject({
+      status: 'recognized',
+      operation: 'ibc-transfer',
+    });
+  });
+});
+
+describe('Operations Kiln does not craft on a given chain are rejected', () => {
+  test('a send on Cosmos Hub, which has no send route', async () => {
+    const verdict = await classify('atom', [sendMsg()]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('does not craft a send operation') });
+  });
+
+  test('a restake grant on Injective, which has no restake route', async () => {
+    const verdict = await classify('injective', [restakeGrantMsg()]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('does not craft a restake-rewards operation') });
+  });
+
+  test('an IBC transfer on Cosmos Hub, which has no transfer route', async () => {
+    const verdict = await classify('atom', [ibcTransferMsg()]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('does not craft a ibc-transfer operation') });
+  });
+
+  test('a stake on Kava, which Kiln Connect no longer serves at all', async () => {
+    const verdict = await classify('kava', [delegateMsg()]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('does not craft transactions on this chain') });
+  });
+
+  test('a stake on ZetaChain, which Kiln Connect no longer serves at all', async () => {
+    expect(await classify('zeta', [delegateMsg()])).toMatchObject({ status: 'unrecognized' });
+  });
+});
+
+describe('Non-Kiln Cosmos transactions are rejected', () => {
+  test('a governance vote', async () => {
+    const verdict = await classify('atom', [{ typeUrl: '/cosmos.gov.v1beta1.MsgVote', value: new Uint8Array([9, 9]) }]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('/cosmos.gov.v1beta1.MsgVote') });
+  });
+
+  test('a send smuggled alongside a valid delegation', async () => {
+    const verdict = await classify('cronos', [delegateMsg(), sendMsg('cosmos1attacker')]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('bundles 2 messages') });
+  });
+
+  test('a grant authorizing undelegation rather than delegation', async () => {
+    const verdict = await classify('atom', [restakeGrantMsg(AuthorizationType.AUTHORIZATION_TYPE_UNDELEGATE)]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('undelegate on your behalf') });
+  });
+
+  test('a stake whose paired grant authorizes undelegation', async () => {
+    const verdict = await classify('atom', [
+      delegateMsg(),
+      restakeGrantMsg(AuthorizationType.AUTHORIZATION_TYPE_UNDELEGATE),
+    ]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('undelegate on your behalf') });
+  });
+
+  test('a grant of some authorization other than StakeAuthorization', async () => {
+    const grant: Any = {
+      typeUrl: '/cosmos.authz.v1beta1.MsgGrant',
+      value: MsgGrant.encode(
+        MsgGrant.fromPartial({
+          granter: delegator,
+          grantee,
+          grant: {
+            expiration: { seconds: 1n },
+            authorization: {
+              typeUrl: '/cosmos.authz.v1beta1.GenericAuthorization',
+              value: new Uint8Array([10, 4, 116, 101, 115, 116]),
+            },
+          },
+        }),
+      ).finish(),
+    };
+    const verdict = await classify('atom', [grant]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('GenericAuthorization') });
+  });
+
+  test('a revoke aimed at an authorization Kiln never granted', async () => {
+    const verdict = await classify('atom', [revokeRestakeMsg('/cosmos.bank.v1beta1.MsgSend')]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('/cosmos.bank.v1beta1.MsgSend') });
+  });
+
+  test('an authz exec, which Kiln never crafts', async () => {
+    const exec: Any = {
+      typeUrl: '/cosmos.authz.v1beta1.MsgExec',
+      value: new Uint8Array([10, 13, 99, 111, 115, 109, 111, 115, 49, 103, 114, 97, 110, 116, 101]),
+    };
+    const verdict = await classify('atom', [exec]);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('authz exec') });
+  });
+
+  test('a transaction with no messages at all', async () => {
+    const verdict = await classify('atom', []);
+
+    expect(verdict.status).toBe('unrecognized');
+    expect(verdict).toMatchObject({ reason: expect.stringContaining('no messages') });
+  });
+});

--- a/packages/cosmos-shared/src/kiln-operations.test.ts
+++ b/packages/cosmos-shared/src/kiln-operations.test.ts
@@ -11,7 +11,7 @@ import { type CosmosChainName, classifyCosmosTransaction } from './kiln-operatio
 import { parseCosmosTx } from './parser';
 
 /**
- * The messages below mirror how services/sof/tx (CosmosMessages + CosmosServiceV2) builds each
+ * The messages below mirror how Kiln's transaction-crafting API builds each
  * operation, so a change on either side shows up here rather than in production.
  */
 
@@ -85,7 +85,7 @@ const sendMsg = (toAddress = 'cosmos1recipient'): Any => ({
   ).finish(),
 });
 
-/** The MsgGrant CosmosMessages.getRestakeRewardsMsg builds. */
+/** The MsgGrant Kiln's restake-rewards route builds. */
 const restakeGrantMsg = (authorizationType = AuthorizationType.AUTHORIZATION_TYPE_DELEGATE): Any => ({
   typeUrl: '/cosmos.authz.v1beta1.MsgGrant',
   value: MsgGrant.encode(

--- a/packages/cosmos-shared/src/kiln-operations.test.ts
+++ b/packages/cosmos-shared/src/kiln-operations.test.ts
@@ -10,10 +10,7 @@ import { MsgTransfer } from 'cosmjs-types/ibc/applications/transfer/v1/tx';
 import { type CosmosChainName, classifyCosmosTransaction } from './kiln-operations';
 import { parseCosmosTx } from './parser';
 
-/**
- * The messages below mirror how Kiln's transaction-crafting API builds each
- * operation, so a change on either side shows up here rather than in production.
- */
+/** These mirror how Kiln crafts each operation, so a drift on either side shows up here. */
 
 const delegator = 'cosmos1delegator';
 const validator = 'cosmosvaloper1kiln';

--- a/packages/cosmos-shared/src/kiln-operations.ts
+++ b/packages/cosmos-shared/src/kiln-operations.ts
@@ -2,23 +2,10 @@ import { recognized, type TransactionVerdict, unrecognized } from '@protocols/sh
 import type { CosmosMessage, CosmosTransaction } from './parser';
 
 /**
- * The Cosmos operations Kiln crafts, per chain.
- *
- * Source of truth is Kiln's transaction-crafting API and the public Kiln Connect spec, which expose the same set:
- * `/{chain}/transaction/{stake,unstake,redelegate,withdraw-rewards,restake-rewards,
- * revoke-restake-rewards,send,noble-ibc-transfer}`. Not every chain exposes all of them, which
- * is exactly why this is keyed per chain rather than shared: a `send` on Cosmos Hub or a
- * restake grant on Injective is not something Kiln produces, and saying so is the point.
- *
- * Every one of those routes builds a single message, with one exception — `stake` with
- * `restake_rewards` set builds a MsgDelegate followed by a MsgGrant — so a genuine Kiln
- * transaction is one message, or that specific pair.
- *
- * Matching is on message shape, not on Kiln's own validator or grantee addresses. Those live
- * in Kiln's configuration and change without minitel knowing; baking them in here would
- * produce a list that silently goes stale and starts rejecting real transactions, which erodes
- * trust in the verdict just as badly as accepting a bad one. The decoded summary below the
- * verdict is where the user checks which validator they are delegating to.
+ * Kiln's Cosmos routes, keyed per chain because the set genuinely differs — a send on Cosmos
+ * Hub or a restake grant on Injective is not something Kiln produces. Each route builds one
+ * message, except stake with restaking on, which builds a MsgDelegate then a MsgGrant.
+ * Matched on message shape, not on Kiln's validator or grantee addresses.
  */
 
 /** Chains minitel ships a Cosmos decoder for. */
@@ -44,12 +31,7 @@ export type CosmosOperation =
   | 'send'
   | 'ibc-transfer';
 
-/**
- * Kava and ZetaChain are deliberately empty: Kiln Connect removed every `/kava/*` and
- * `/zeta/*` endpoint in API v1.10, so there is no such thing as a Kiln transaction on those
- * chains any more and nothing minitel can vouch for. The apps are candidates for removal the
- * way DOT, KSM and Mantra were.
- */
+/** Kava and ZetaChain are empty: Kiln Connect removed those endpoints in API v1.10. */
 const KILN_OPERATIONS_BY_CHAIN: Record<CosmosChainName, ReadonlySet<CosmosOperation>> = {
   atom: new Set(['stake', 'unstake', 'redelegate', 'withdraw-rewards', 'restake-rewards', 'revoke-restake-rewards']),
   cronos: new Set([
@@ -80,19 +62,17 @@ const KILN_OPERATIONS_BY_CHAIN: Record<CosmosChainName, ReadonlySet<CosmosOperat
   zeta: new Set([]),
 };
 
-/** The message Kiln's revoke-restake-rewards route revokes authorization for. */
+/** What the revoke-restake-rewards route revokes authorization for. */
 const DELEGATE_MSG_TYPE_URL = '/cosmos.staking.v1beta1.MsgDelegate';
 
-/** A rejection carrying the reason, or the operation a message set resolves to. */
+/** Either the operation a message set resolves to, or why it was rejected. */
 type Match = { operation: CosmosOperation } | { rejection: string };
 
 const isRejection = (match: Match): match is { rejection: string } => 'rejection' in match;
 
 /**
- * Kiln's restake grant authorizes one thing: delegating to a named validator on the user's
- * behalf. A StakeAuthorization can just as easily authorize undelegation or redelegation, and
- * a grant of some other authorization type can authorize anything at all — none of which is
- * visible from the `MsgGrant` typeUrl the summary shows.
+ * The restake grant authorizes delegation and nothing else. A StakeAuthorization can just as
+ * easily authorize undelegation, and none of that is visible from the typeUrl alone.
  */
 const matchRestakeGrant = (message: Extract<CosmosMessage, { kind: 'authzGrant' }>): Match => {
   const { stakeAuthorization } = message;
@@ -146,12 +126,8 @@ const matchMessage = (message: CosmosMessage): Match => {
 };
 
 /**
- * A single stake route emits a MsgDelegate plus the MsgGrant that turns on restaking, so the
- * pair is one operation rather than a bundle. It needs both halves to be operations the chain
- * offers, since that one route is what produces it.
- *
- * Returns null when the messages are not that pair at all, leaving the caller to fall through
- * to the ordinary single-message path.
+ * The stake-with-restaking pair is one operation rather than a bundle. Returns null when the
+ * messages are not that pair, so the caller falls through to the single-message path.
  */
 const matchStakeWithRestake = (
   messages: CosmosMessage[],

--- a/packages/cosmos-shared/src/kiln-operations.ts
+++ b/packages/cosmos-shared/src/kiln-operations.ts
@@ -4,8 +4,7 @@ import type { CosmosMessage, CosmosTransaction } from './parser';
 /**
  * The Cosmos operations Kiln crafts, per chain.
  *
- * Source of truth is the crafting service (services/sof/tx, the per-chain controllers over
- * CosmosServiceV2) and the public Kiln Connect spec, which expose the same set:
+ * Source of truth is Kiln's transaction-crafting API and the public Kiln Connect spec, which expose the same set:
  * `/{chain}/transaction/{stake,unstake,redelegate,withdraw-rewards,restake-rewards,
  * revoke-restake-rewards,send,noble-ibc-transfer}`. Not every chain exposes all of them, which
  * is exactly why this is keyed per chain rather than shared: a `send` on Cosmos Hub or a

--- a/packages/cosmos-shared/src/kiln-operations.ts
+++ b/packages/cosmos-shared/src/kiln-operations.ts
@@ -1,0 +1,205 @@
+import { recognized, type TransactionVerdict, unrecognized } from '@protocols/shared';
+import type { CosmosMessage, CosmosTransaction } from './parser';
+
+/**
+ * The Cosmos operations Kiln crafts, per chain.
+ *
+ * Source of truth is the crafting service (services/sof/tx, the per-chain controllers over
+ * CosmosServiceV2) and the public Kiln Connect spec, which expose the same set:
+ * `/{chain}/transaction/{stake,unstake,redelegate,withdraw-rewards,restake-rewards,
+ * revoke-restake-rewards,send,noble-ibc-transfer}`. Not every chain exposes all of them, which
+ * is exactly why this is keyed per chain rather than shared: a `send` on Cosmos Hub or a
+ * restake grant on Injective is not something Kiln produces, and saying so is the point.
+ *
+ * Every one of those routes builds a single message, with one exception — `stake` with
+ * `restake_rewards` set builds a MsgDelegate followed by a MsgGrant — so a genuine Kiln
+ * transaction is one message, or that specific pair.
+ *
+ * Matching is on message shape, not on Kiln's own validator or grantee addresses. Those live
+ * in Kiln's configuration and change without minitel knowing; baking them in here would
+ * produce a list that silently goes stale and starts rejecting real transactions, which erodes
+ * trust in the verdict just as badly as accepting a bad one. The decoded summary below the
+ * verdict is where the user checks which validator they are delegating to.
+ */
+
+/** Chains minitel ships a Cosmos decoder for. */
+export type CosmosChainName =
+  | 'atom'
+  | 'cronos'
+  | 'dydx'
+  | 'fetch'
+  | 'injective'
+  | 'kava'
+  | 'osmosis'
+  | 'sei'
+  | 'tia'
+  | 'zeta';
+
+export type CosmosOperation =
+  | 'stake'
+  | 'unstake'
+  | 'redelegate'
+  | 'withdraw-rewards'
+  | 'restake-rewards'
+  | 'revoke-restake-rewards'
+  | 'send'
+  | 'ibc-transfer';
+
+/**
+ * Kava and ZetaChain are deliberately empty: Kiln Connect removed every `/kava/*` and
+ * `/zeta/*` endpoint in API v1.10, so there is no such thing as a Kiln transaction on those
+ * chains any more and nothing minitel can vouch for. The apps are candidates for removal the
+ * way DOT, KSM and Mantra were.
+ */
+const KILN_OPERATIONS_BY_CHAIN: Record<CosmosChainName, ReadonlySet<CosmosOperation>> = {
+  atom: new Set(['stake', 'unstake', 'redelegate', 'withdraw-rewards', 'restake-rewards', 'revoke-restake-rewards']),
+  cronos: new Set([
+    'stake',
+    'unstake',
+    'redelegate',
+    'withdraw-rewards',
+    'restake-rewards',
+    'revoke-restake-rewards',
+    'send',
+  ]),
+  // dYdX pays rewards in USDC on Noble, so it alone exposes an IBC transfer route.
+  dydx: new Set(['stake', 'unstake', 'redelegate', 'withdraw-rewards', 'ibc-transfer']),
+  fetch: new Set([
+    'stake',
+    'unstake',
+    'redelegate',
+    'withdraw-rewards',
+    'restake-rewards',
+    'revoke-restake-rewards',
+    'send',
+  ]),
+  injective: new Set(['stake', 'unstake', 'redelegate', 'withdraw-rewards']),
+  kava: new Set([]),
+  osmosis: new Set(['stake', 'unstake', 'redelegate', 'withdraw-rewards', 'restake-rewards', 'revoke-restake-rewards']),
+  sei: new Set(['stake', 'unstake', 'redelegate', 'withdraw-rewards', 'send']),
+  tia: new Set(['stake', 'unstake', 'redelegate', 'withdraw-rewards', 'restake-rewards', 'revoke-restake-rewards']),
+  zeta: new Set([]),
+};
+
+/** The message Kiln's revoke-restake-rewards route revokes authorization for. */
+const DELEGATE_MSG_TYPE_URL = '/cosmos.staking.v1beta1.MsgDelegate';
+
+/** A rejection carrying the reason, or the operation a message set resolves to. */
+type Match = { operation: CosmosOperation } | { rejection: string };
+
+const isRejection = (match: Match): match is { rejection: string } => 'rejection' in match;
+
+/**
+ * Kiln's restake grant authorizes one thing: delegating to a named validator on the user's
+ * behalf. A StakeAuthorization can just as easily authorize undelegation or redelegation, and
+ * a grant of some other authorization type can authorize anything at all — none of which is
+ * visible from the `MsgGrant` typeUrl the summary shows.
+ */
+const matchRestakeGrant = (message: Extract<CosmosMessage, { kind: 'authzGrant' }>): Match => {
+  const { stakeAuthorization } = message;
+
+  if (!stakeAuthorization) {
+    return {
+      rejection: `This transaction grants ${message.grantee} a ${message.authorizationType} authorization. Kiln only grants a staking authorization to restake rewards.`,
+    };
+  }
+
+  if (stakeAuthorization.authorizationType !== 'delegate') {
+    return {
+      rejection: `This transaction authorizes ${message.grantee} to ${stakeAuthorization.authorizationType} on your behalf. Kiln's restake-rewards grant only authorizes delegation.`,
+    };
+  }
+
+  return { operation: 'restake-rewards' };
+};
+
+const matchMessage = (message: CosmosMessage): Match => {
+  switch (message.kind) {
+    case 'delegate':
+      return { operation: 'stake' };
+    case 'undelegate':
+      return { operation: 'unstake' };
+    case 'redelegate':
+      return { operation: 'redelegate' };
+    case 'withdrawRewards':
+      return { operation: 'withdraw-rewards' };
+    case 'send':
+      return { operation: 'send' };
+    case 'ibcTransfer':
+      return { operation: 'ibc-transfer' };
+    case 'authzGrant':
+      return matchRestakeGrant(message);
+    case 'authzRevoke':
+      return message.msgTypeUrl === DELEGATE_MSG_TYPE_URL
+        ? { operation: 'revoke-restake-rewards' }
+        : {
+            rejection: `This transaction revokes a ${message.msgTypeUrl} authorization. Kiln only revokes the delegation authorization it granted to restake rewards.`,
+          };
+    case 'authzExec':
+      return {
+        rejection: `This transaction lets ${message.grantee} execute ${message.innerTypeUrls.length} message(s) on your behalf. Kiln never crafts an authz exec.`,
+      };
+    default:
+      return {
+        rejection: `This transaction contains a ${message.typeUrl || 'nameless'} message minitel could not decode.`,
+      };
+  }
+};
+
+/**
+ * A single stake route emits a MsgDelegate plus the MsgGrant that turns on restaking, so the
+ * pair is one operation rather than a bundle. It needs both halves to be operations the chain
+ * offers, since that one route is what produces it.
+ *
+ * Returns null when the messages are not that pair at all, leaving the caller to fall through
+ * to the ordinary single-message path.
+ */
+const matchStakeWithRestake = (
+  messages: CosmosMessage[],
+  supported: ReadonlySet<CosmosOperation>,
+): TransactionVerdict | null => {
+  const [first, second] = messages;
+  if (messages.length !== 2 || first.kind !== 'delegate' || second.kind !== 'authzGrant') return null;
+  if (!supported.has('stake') || !supported.has('restake-rewards')) return null;
+
+  const grant = matchRestakeGrant(second);
+  return isRejection(grant) ? unrecognized(grant.rejection) : recognized('stake-with-restake-rewards');
+};
+
+export const classifyCosmosTransaction = (
+  chain: CosmosChainName,
+  transaction: CosmosTransaction,
+): TransactionVerdict => {
+  const supported = KILN_OPERATIONS_BY_CHAIN[chain];
+  const { messages } = transaction;
+
+  if (messages.length === 0) {
+    return unrecognized('This transaction contains no messages.');
+  }
+
+  if (supported.size === 0) {
+    return unrecognized('Kiln does not craft transactions on this chain, so no transaction on it can be a Kiln one.');
+  }
+
+  const stakeWithRestake = matchStakeWithRestake(messages, supported);
+  if (stakeWithRestake) {
+    return stakeWithRestake;
+  }
+
+  if (messages.length > 1) {
+    return unrecognized(
+      `This transaction bundles ${messages.length} messages. Kiln operations carry one, except a stake that also turns on restaking.`,
+    );
+  }
+
+  const match = matchMessage(messages[0]);
+  if (isRejection(match)) {
+    return unrecognized(match.rejection);
+  }
+
+  if (!supported.has(match.operation)) {
+    return unrecognized(`Kiln does not craft a ${match.operation} operation on this chain.`);
+  }
+
+  return recognized(match.operation);
+};

--- a/packages/cosmos-shared/src/parser.ts
+++ b/packages/cosmos-shared/src/parser.ts
@@ -2,13 +2,25 @@ import { type DecodedTxRaw, decodeTxRaw } from '@cosmjs/proto-signing';
 import { MsgExec, MsgGrant, MsgRevoke } from 'cosmjs-types/cosmos/authz/v1beta1/tx';
 import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx';
 import { MsgWithdrawDelegatorReward } from 'cosmjs-types/cosmos/distribution/v1beta1/tx';
+import { AuthorizationType, StakeAuthorization } from 'cosmjs-types/cosmos/staking/v1beta1/authz';
 import { MsgBeginRedelegate, MsgDelegate, MsgUndelegate } from 'cosmjs-types/cosmos/staking/v1beta1/tx';
 import type { Any } from 'cosmjs-types/google/protobuf/any';
+import { MsgTransfer } from 'cosmjs-types/ibc/applications/transfer/v1/tx';
 
 /** A normalized coin amount, always rendered as decimal strings (never bigint). */
 export type CosmosCoin = {
   denom: string;
   amount: string;
+};
+
+/** What a `/cosmos.staking.v1beta1.StakeAuthorization` grant actually permits. */
+export type CosmosStakeAuthorization = {
+  /** 'unspecified' also covers an authorization type this cosmjs version does not name. */
+  authorizationType: 'unspecified' | 'delegate' | 'undelegate' | 'redelegate' | 'cancelUnbondingDelegation';
+  allowList: string[];
+  denyList: string[];
+  /** Absent means the grant is unbounded. */
+  maxTokens: CosmosCoin | null;
 };
 
 /**
@@ -50,7 +62,15 @@ export type CosmosMessage =
       typeUrl: string;
       granter: string;
       grantee: string;
+      /** typeUrl of the granted authorization, e.g. '/cosmos.staking.v1beta1.StakeAuthorization'. */
       authorizationType: string;
+      /**
+       * The decoded StakeAuthorization body, or null when the grant is some other kind of
+       * authorization. The typeUrl alone says nothing about what the grantee may do: a
+       * StakeAuthorization can authorize undelegation to an arbitrary validator just as
+       * easily as the delegation Kiln's restake grant asks for.
+       */
+      stakeAuthorization: CosmosStakeAuthorization | null;
     }
   | {
       kind: 'authzExec';
@@ -64,6 +84,15 @@ export type CosmosMessage =
       granter: string;
       grantee: string;
       msgTypeUrl: string;
+    }
+  | {
+      kind: 'ibcTransfer';
+      typeUrl: string;
+      sender: string;
+      receiver: string;
+      sourcePort: string;
+      sourceChannel: string;
+      token: CosmosCoin | null;
     }
   | {
       kind: 'unsupported';
@@ -94,6 +123,7 @@ const TYPE_URLS = {
   authzGrant: '/cosmos.authz.v1beta1.MsgGrant',
   authzExec: '/cosmos.authz.v1beta1.MsgExec',
   authzRevoke: '/cosmos.authz.v1beta1.MsgRevoke',
+  ibcTransfer: '/ibc.applications.transfer.v1.MsgTransfer',
 } as const;
 
 const bytesToHex = (bytes: Uint8Array): string =>
@@ -106,6 +136,36 @@ const toCoin = (coin: { denom: string; amount: string } | undefined | null): Cos
 
 const toCoins = (coins: ReadonlyArray<{ denom: string; amount: string }>): CosmosCoin[] =>
   coins.map((coin) => ({ denom: coin.denom, amount: coin.amount }));
+
+const STAKE_AUTHORIZATION_TYPE_URL = '/cosmos.staking.v1beta1.StakeAuthorization';
+
+const AUTHORIZATION_TYPES: Record<number, CosmosStakeAuthorization['authorizationType']> = {
+  [AuthorizationType.AUTHORIZATION_TYPE_DELEGATE]: 'delegate',
+  [AuthorizationType.AUTHORIZATION_TYPE_UNDELEGATE]: 'undelegate',
+  [AuthorizationType.AUTHORIZATION_TYPE_REDELEGATE]: 'redelegate',
+  [AuthorizationType.AUTHORIZATION_TYPE_CANCEL_UNBONDING_DELEGATION]: 'cancelUnbondingDelegation',
+};
+
+/**
+ * Decode the authorization nested inside a `MsgGrant`. Returns null for anything that is not a
+ * StakeAuthorization, and for a StakeAuthorization whose bytes do not decode — in both cases
+ * the caller has to treat the grant as unaccountable rather than assume it is harmless.
+ */
+const decodeStakeAuthorization = (authorization: Any | undefined): CosmosStakeAuthorization | null => {
+  if (!authorization || authorization.typeUrl !== STAKE_AUTHORIZATION_TYPE_URL) return null;
+
+  try {
+    const decoded = StakeAuthorization.decode(authorization.value);
+    return {
+      authorizationType: AUTHORIZATION_TYPES[decoded.authorizationType] ?? 'unspecified',
+      allowList: decoded.allowList?.address ?? [],
+      denyList: decoded.denyList?.address ?? [],
+      maxTokens: toCoin(decoded.maxTokens),
+    };
+  } catch {
+    return null;
+  }
+};
 
 /**
  * Decode a single protobuf `Any` message body by its `typeUrl`. All values are
@@ -175,6 +235,7 @@ const decodeMessage = (message: Any): CosmosMessage => {
           granter: msg.granter,
           grantee: msg.grantee,
           authorizationType: msg.grant?.authorization?.typeUrl ?? 'unknown',
+          stakeAuthorization: decodeStakeAuthorization(msg.grant?.authorization),
         };
       }
       case TYPE_URLS.authzExec: {
@@ -194,6 +255,18 @@ const decodeMessage = (message: Any): CosmosMessage => {
           granter: msg.granter,
           grantee: msg.grantee,
           msgTypeUrl: msg.msgTypeUrl,
+        };
+      }
+      case TYPE_URLS.ibcTransfer: {
+        const msg = MsgTransfer.decode(value);
+        return {
+          kind: 'ibcTransfer',
+          typeUrl,
+          sender: msg.sender,
+          receiver: msg.receiver,
+          sourcePort: msg.sourcePort,
+          sourceChannel: msg.sourceChannel,
+          token: toCoin(msg.token),
         };
       }
       default:

--- a/packages/cosmos-shared/src/parser.ts
+++ b/packages/cosmos-shared/src/parser.ts
@@ -64,12 +64,7 @@ export type CosmosMessage =
       grantee: string;
       /** typeUrl of the granted authorization, e.g. '/cosmos.staking.v1beta1.StakeAuthorization'. */
       authorizationType: string;
-      /**
-       * The decoded StakeAuthorization body, or null when the grant is some other kind of
-       * authorization. The typeUrl alone says nothing about what the grantee may do: a
-       * StakeAuthorization can authorize undelegation to an arbitrary validator just as
-       * easily as the delegation Kiln's restake grant asks for.
-       */
+      /** Null for any other authorization. The typeUrl alone says nothing about what is granted. */
       stakeAuthorization: CosmosStakeAuthorization | null;
     }
   | {
@@ -146,11 +141,7 @@ const AUTHORIZATION_TYPES: Record<number, CosmosStakeAuthorization['authorizatio
   [AuthorizationType.AUTHORIZATION_TYPE_CANCEL_UNBONDING_DELEGATION]: 'cancelUnbondingDelegation',
 };
 
-/**
- * Decode the authorization nested inside a `MsgGrant`. Returns null for anything that is not a
- * StakeAuthorization, and for a StakeAuthorization whose bytes do not decode — in both cases
- * the caller has to treat the grant as unaccountable rather than assume it is harmless.
- */
+/** Null for a non-StakeAuthorization or bytes that do not decode; both are unaccountable. */
 const decodeStakeAuthorization = (authorization: Any | undefined): CosmosStakeAuthorization | null => {
   if (!authorization || authorization.typeUrl !== STAKE_AUTHORIZATION_TYPE_URL) return null;
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './config/protocols';
 export * from './types/playbook';
 export * from './types/protocol-adapter';
+export * from './types/verdict';
 export * from './utils';

--- a/packages/shared/src/types/protocol-adapter.ts
+++ b/packages/shared/src/types/protocol-adapter.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import type { Protocol } from '../config/protocols';
+import type { TransactionVerdict } from './verdict';
 
 export type ManualInputField = {
   key: string;
@@ -16,6 +17,13 @@ export type ProtocolAdapter<TDecodedTransaction> = {
 
   parseTransaction: (rawTx: string) => Promise<TDecodedTransaction>;
   computeHash: (rawTx: string) => string | Promise<string>;
+
+  /**
+   * Decide whether this transaction is one Kiln produces. Required, not optional: a decoder
+   * with no opinion is a decoder that silently vouches for anything. Protocols without an
+   * allowlist yet use `pendingAllowlist`, which answers "not checked" rather than nothing.
+   */
+  classifyTransaction: (data: TDecodedTransaction) => TransactionVerdict;
 
   renderSummary?: (data: TDecodedTransaction, hash?: string) => ReactNode;
 

--- a/packages/shared/src/types/verdict.ts
+++ b/packages/shared/src/types/verdict.ts
@@ -26,6 +26,21 @@ export const unrecognized = (reason: string): TransactionVerdict => ({
 });
 
 /**
+ * For the narrow case where a protocol has an allowlist, the transaction matches the shape of a
+ * Kiln operation, but the thing that would make it safe is not knowable here — typically an
+ * address that lives in Kiln's configuration.
+ *
+ * Unlike [pendingAllowlist] this is a considered answer about a specific transaction, so the
+ * reason has to name what minitel could not check and what the user should check instead.
+ * Reach for it sparingly: a verdict of "maybe" on an operation that could have been decided is
+ * worse than either answer.
+ */
+export const unverified = (reason: string): TransactionVerdict => ({
+  status: 'unverified',
+  reason,
+});
+
+/**
  * Verdict for protocols whose Kiln allowlist has not been written yet.
  *
  * `classifyTransaction` is deliberately required on ProtocolAdapter: making the verdict

--- a/packages/shared/src/types/verdict.ts
+++ b/packages/shared/src/types/verdict.ts
@@ -1,0 +1,44 @@
+/**
+ * Kiln crafts a closed set of operations per protocol — the crafting routes exposed by the
+ * internal tx service. minitel exists so a customer can verify one of those before signing it.
+ *
+ * A transaction that matches none of them is not something minitel can vouch for, however
+ * cleanly it happens to decode. Decoding it generically and rendering a confident summary is
+ * the failure mode this type exists to prevent: as protocols grow extensions we do not
+ * support, a best-effort decode reads to the user exactly like a verified one.
+ */
+export type TransactionVerdict =
+  /** Matched a known Kiln operation. `operation` names it, e.g. 'stake', 'merge-stakes'. */
+  | { status: 'recognized'; operation: string }
+  /** The protocol has an allowlist and this transaction matched nothing in it. */
+  | { status: 'unrecognized'; reason: string }
+  /** The protocol has no allowlist yet, so minitel cannot answer either way. */
+  | { status: 'unverified'; reason: string };
+
+export const recognized = (operation: string): TransactionVerdict => ({
+  status: 'recognized',
+  operation,
+});
+
+export const unrecognized = (reason: string): TransactionVerdict => ({
+  status: 'unrecognized',
+  reason,
+});
+
+/**
+ * Verdict for protocols whose Kiln allowlist has not been written yet.
+ *
+ * `classifyTransaction` is deliberately required on ProtocolAdapter: making the verdict
+ * optional is how several decoders came to ship with no safety logic at all, with nothing in
+ * the type system objecting. A protocol that has not been done yet has to say so out loud
+ * rather than stay silent — and `pendingAllowlist` is greppable, so the remaining work is
+ * always countable.
+ *
+ * This never returns 'recognized'. It cannot produce a false reassurance, only an honest
+ * "not checked".
+ */
+export const pendingAllowlist = (): TransactionVerdict => ({
+  status: 'unverified',
+  reason:
+    'This decoder does not yet know which operations Kiln produces on this chain, so it cannot confirm that this transaction is one of them.',
+});

--- a/packages/shared/src/types/verdict.ts
+++ b/packages/shared/src/types/verdict.ts
@@ -26,14 +26,9 @@ export const unrecognized = (reason: string): TransactionVerdict => ({
 });
 
 /**
- * For the narrow case where a protocol has an allowlist, the transaction matches the shape of a
- * Kiln operation, but the thing that would make it safe is not knowable here — typically an
- * address that lives in Kiln's configuration.
- *
- * Unlike [pendingAllowlist] this is a considered answer about a specific transaction, so the
- * reason has to name what minitel could not check and what the user should check instead.
- * Reach for it sparingly: a verdict of "maybe" on an operation that could have been decided is
- * worse than either answer.
+ * For a transaction that matches a Kiln operation's shape but whose safety turns on something
+ * not knowable here — typically an address in Kiln's configuration. The reason must name what
+ * to check instead. Use sparingly: a "maybe" on a decidable operation is worse than either answer.
  */
 export const unverified = (reason: string): TransactionVerdict => ({
   status: 'unverified',

--- a/packages/ui/src/components/protocol-transaction-decoder.tsx
+++ b/packages/ui/src/components/protocol-transaction-decoder.tsx
@@ -28,7 +28,7 @@ export function ProtocolTransactionDecoder<T>({ adapter }: ProtocolTransactionDe
   const [isManualMode, setIsManualMode] = useState(false);
   const [manualFields, setManualFields] = useState<Record<string, string>>(initialManualFields);
 
-  const { decodedTransaction, hash, error, warnings, decodeTransaction } = useTransactionDecoder(adapter);
+  const { decodedTransaction, hash, error, verdict, warnings, decodeTransaction } = useTransactionDecoder(adapter);
 
   const handleManualFieldChange = (field: string, value: string) => {
     setManualFields((prev) => ({ ...prev, [field]: value }));
@@ -54,6 +54,7 @@ export function ProtocolTransactionDecoder<T>({ adapter }: ProtocolTransactionDe
       onDecode={handleDecode}
       decodedTransaction={decodedTransaction}
       hash={hash}
+      verdict={verdict}
       warnings={warnings}
       renderSummary={adapter.renderSummary ? (data: T) => adapter.renderSummary?.(data, hash) : undefined}
       placeholder={adapter.placeholder ?? 'Paste your transaction'}

--- a/packages/ui/src/components/transaction-decoder.tsx
+++ b/packages/ui/src/components/transaction-decoder.tsx
@@ -1,4 +1,4 @@
-import type { ManualInputField, Protocol } from '@protocols/shared';
+import type { ManualInputField, Protocol, TransactionVerdict } from '@protocols/shared';
 import JsonView from '@uiw/react-json-view';
 import { githubLightTheme } from '@uiw/react-json-view/githubLight';
 import { vscodeTheme } from '@uiw/react-json-view/vscode';
@@ -8,6 +8,9 @@ import {
   DownloadIcon,
   InboxIcon,
   InfoIcon,
+  OctagonAlertIcon,
+  ShieldCheckIcon,
+  ShieldQuestionIcon,
   TriangleAlertIcon,
   ZapIcon,
 } from 'lucide-react';
@@ -40,6 +43,7 @@ export type TransactionDecoderProps<T> = {
   onDecode: () => void;
   decodedTransaction: T | null;
   hash?: string;
+  verdict?: TransactionVerdict | null;
   warnings?: Array<{ message: string }>;
   renderSummary?: (data: T) => React.ReactNode;
   placeholder?: string;
@@ -53,6 +57,54 @@ export type TransactionDecoderProps<T> = {
   onManualFieldChange?: (field: string, value: string) => void;
 };
 
+/**
+ * The headline answer: is this one of the operations Kiln produces?
+ *
+ * It sits above the decoded details deliberately. The details are still rendered for every
+ * verdict — withholding them only pushes people to decode elsewhere — but an unrecognized
+ * transaction must not be able to borrow the credibility of a clean-looking summary.
+ */
+function VerdictAlert({ verdict }: { verdict: TransactionVerdict }) {
+  if (verdict.status === 'recognized') {
+    return (
+      <Alert
+        className="border-emerald-600/40 text-emerald-700 dark:border-emerald-400/30 dark:text-emerald-400"
+        data-test={DataTests.transaction_decoder_verdict}
+        data-verdict="recognized"
+      >
+        <ShieldCheckIcon />
+        <AlertTitle>Kiln operation — {verdict.operation}</AlertTitle>
+        <AlertDescription className="text-emerald-700/90 dark:text-emerald-400/90">
+          This matches a transaction Kiln produces. Check the details below against what you asked for.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (verdict.status === 'unverified') {
+    return (
+      <Alert variant="warning" data-test={DataTests.transaction_decoder_verdict} data-verdict="unverified">
+        <ShieldQuestionIcon />
+        <AlertTitle>Not checked against Kiln operations</AlertTitle>
+        <AlertDescription>{verdict.reason}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <Alert variant="destructive" data-test={DataTests.transaction_decoder_verdict} data-verdict="unrecognized">
+      <OctagonAlertIcon />
+      <AlertTitle>Not a Kiln operation</AlertTitle>
+      <AlertDescription>
+        <p>{verdict.reason}</p>
+        <p>
+          Do not sign this on Kiln's authority. The details below are a best-effort decode and are not verified.
+        </p>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
 export function TransactionDecoder<T>({
   title = 'Transaction decoder',
   subtitle = 'Decode and analyze transactions',
@@ -61,6 +113,7 @@ export function TransactionDecoder<T>({
   onDecode,
   decodedTransaction,
   hash,
+  verdict,
   warnings = [],
   renderSummary,
   placeholder = 'Paste your transaction as hex or JSON',
@@ -322,6 +375,7 @@ export function TransactionDecoder<T>({
                   <AlertDescription className="text-sm overflow-y-auto max-h-40 break-all">{error}</AlertDescription>
                 </Alert>
               )}
+              {verdict && <VerdictAlert verdict={verdict} />}
               {warningsAmount > 0 && (
                 <Alert variant="warning" data-test={DataTests.transaction_decoder_warning}>
                   <TriangleAlertIcon />

--- a/packages/ui/src/hooks/useTransactionDecoder.ts
+++ b/packages/ui/src/hooks/useTransactionDecoder.ts
@@ -1,4 +1,4 @@
-import type { ProtocolAdapter } from '@protocols/shared';
+import type { ProtocolAdapter, TransactionVerdict } from '@protocols/shared';
 import { useCallback, useState } from 'react';
 import { convertBigIntToString } from '../lib/utils';
 
@@ -6,6 +6,7 @@ export type UseTransactionDecoderResult<T> = {
   decodedTransaction: T | null;
   hash: string;
   error?: string;
+  verdict: TransactionVerdict | null;
   warnings: Array<{ message: string }>;
   decodeTransaction: (rawTx: string) => Promise<void>;
   isLoading: boolean;
@@ -47,10 +48,25 @@ export function useTransactionDecoder<T>(adapter: ProtocolAdapter<T>): UseTransa
 
   const warnings = decodedTransaction ? (adapter.generateWarnings?.(decodedTransaction) ?? []) : [];
 
+  // A classifier that throws must not read as "no objection" — fall closed to unrecognized.
+  const classify = (data: T): TransactionVerdict => {
+    try {
+      return adapter.classifyTransaction(data);
+    } catch {
+      return {
+        status: 'unrecognized',
+        reason: 'This transaction could not be checked against the operations Kiln produces.',
+      };
+    }
+  };
+
+  const verdict = decodedTransaction ? classify(decodedTransaction) : null;
+
   return {
     decodedTransaction,
     hash,
     error,
+    verdict,
     warnings,
     decodeTransaction,
     isLoading,

--- a/packages/ui/src/lib/data-tests.ts
+++ b/packages/ui/src/lib/data-tests.ts
@@ -13,5 +13,6 @@ export enum DataTests {
   transaction_decoder_tab_summary_trigger = 'transaction_decoder_tab_summary_trigger',
   transaction_decoder_tab_json_trigger = 'transaction_decoder_tab_json_trigger',
   transaction_decoder_warning = 'transaction_decoder_warning',
-  transaction_decoder_error = 'transaction_decoder_error'
+  transaction_decoder_error = 'transaction_decoder_error',
+  transaction_decoder_verdict = 'transaction_decoder_verdict'
 }


### PR DESCRIPTION
## What

Every decoder must now answer one question before anything else: is this a transaction Kiln
produces? `ProtocolAdapter` gains a required `classifyTransaction` returning `recognized`,
`unrecognized` or `unverified`, and the answer renders as a banner above the decoded details.
The decoded summary is still rendered for every verdict — withholding it only sends people to
decode somewhere less careful — but an unrecognized transaction no longer borrows the
credibility of a clean-looking summary.

Required, not optional: `generateWarnings` was optional, and six of the eighteen decoders
shipped with no safety logic at all. A classifier that throws falls closed to `unrecognized`.

**Four allowlists ship here, covering 13 of 18 apps.** Each is derived from the crafting routes
the public Kiln Connect spec exposes.

*Solana* matches on instruction shape: each of its five routes is a durable-nonce advance plus
one Stake Program action, with compute-budget and memo instructions treated as envelope.

*NEAR* matches on a single FunctionCall to a known staking method, and rejects a deposit
attached to an unstake or a withdraw — both are crafted with zero.

*Cosmos* keys the operation set per chain, because it genuinely differs: `send` exists on
cronos, fetch and sei only; `restake-rewards` on atom, tia, osmosis, cronos and fetch; an IBC
transfer only on dydx. Kava and zeta are empty — Kiln Connect removed those endpoints in API
v1.10 — so nothing on those chains can be a Kiln transaction, and the apps are candidates for
removal the way DOT, KSM and Mantra were. The chain name is typed as a union so a new Cosmos app
cannot be added without declaring its operations.

*Ethereum* matches on the decoded function for ordinary calls. Two operations have no ABI at
all — validator exits and consolidations are raw payloads sent to the EIP-7002 and EIP-7251
predeploys — so those are matched on address plus payload shape, which is safe because the
predeploys are protocol constants rather than configuration. An exit is a withdrawal request
with a zero amount, and enabling compounding is a consolidation of a validator onto itself, so
each pair is told apart by reading the payload. EigenLayer's calls are deliberately absent:
Kiln Connect dropped EigenLayer in API v1.10, so `delegateTo`, `undelegate`, `createPod` and
`completeQueuedWithdrawals` are no longer operations Kiln produces even though the ABIs to
decode them are still bundled. The async-vault operator functions are absent for the same
reason — a customer asked to sign `settleDeposit` or `close` is the case worth flagging.

Two Cosmos parser gaps had to close first. A `MsgGrant` now decodes the `StakeAuthorization`
nested inside it, so a grant that authorizes *undelegation* rather than delegation is rejected
instead of passing as restake-rewards on its typeUrl alone. IBC `MsgTransfer` now decodes, so
dydx's reward transfer to Noble reads as a recognized operation rather than an unsupported
message.

None of the allowlists match on Kiln's own vote accounts, staking pools, validators, vaults or
grantee addresses. Those live in Kiln's configuration and go stale here without minitel knowing,
and a list that starts rejecting real transactions erodes trust in the verdict just as badly as
one that accepts bad ones. The decoded summary underneath is where a user checks which validator
they are staking with. The single exception is the DeFi token approval, whose whole safety rests
on the spender being a Kiln vault: that returns `unverified` with a reason naming what to check,
since calling it recognized would rubber-stamp an approval to a drainer and calling it
unrecognized would reject a real operation.

**Also in scope: chain-id gating on Ethereum.** The address-to-ABI map was keyed by destination
address alone, so a transaction on any other EVM chain that targeted one of those addresses was
rendered as a known Ethereum protocol action. Protocol decoding is now gated on mainnet, sepolia
and hoodi, and the chain is part of the verdict rather than only of the decode — a Kiln-shaped
call on Base is rejected outright.

**Two summary bugs the verdict exposed.** The risk badge read HIGH RISK on every decoded
transaction, because 38 of the 41 Ethereum action handlers returned `riskLevel: 'high'` with a
matching "X is a high risk operation" warning; a routine stake and a drainer approval looked
identical. Those strings were a proxy for "we do not know if this is safe", which is what the
verdict now answers, so handlers only describe and the verdict judges. And "Transaction type"
was a hardcoded `<Badge>Approval</Badge>` — it said Approval for every transaction ever decoded,
including validator exits.

ADA, SUI, TON and TRX remain unclassified — one chain at a time, so the allowlist, the part that
genuinely needs review, stays reviewable.

## Verification

`bun test` — 76 tests across 7 files, all passing. 22 for Cosmos, 16 for Ethereum, 13 for NEAR,
7 for the chain gate, 10 for Solana, plus the pre-existing Cosmos parser tests. They build real
transactions with the same libraries the crafting service uses, serialize them, and run them
through the actual parsers, asserting both directions.

The rejection cases are the point: an undelegate-authorizing grant, a GenericAuthorization
grant, a send smuggled next to a valid delegation, a deposit attached to `withdraw_all`, an
operation on a chain that has no such route, a malformed predeploy payload, an EigenLayer call,
a vault administration call, and the same Kiln-shaped calldata replayed on Base, Arbitrum,
Optimism and Polygon PoS.

`bun run lint` and `bun run build` pass for all 18 workspaces. Test files are excluded from
`tsc` in the app tsconfigs, matching what `cosmos-shared` already did — `@protocols/solana` lint
had been failing on `bun:test` types since those tests landed, and this fixes it. The tradeoff
is that test files are not type-checked; adding `@types/bun` per workspace is the alternative,
and I left it out rather than add a dependency.

Paste-ready payloads for every case, with the verdict each one actually returns:
https://claude.ai/code/artifact/a7f3d74a-8750-4396-b116-e820bda3eb32

Not verified: the rendered banner and the reworked summary badges have been checked by build and
by one manual paste, not systematically by eye.
