### PR TITLE
fix(STA-280): unblock the minitel production deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,10 @@ jobs:
       contents: read
       deployments: write
     strategy:
+      # One app's failure must not cancel the other seventeen: with fail-fast on, the
+      # first job to fail hid the state of every other deploy, so a single broken app
+      # read as "the deploy is broken" and the ones that would have shipped never ran.
+      fail-fast: false
       matrix:
         app: [ethereum, solana, near, zeta, tia, sei, osmosis, injective, fetch, dydx, cronos, atom, kava, ada, sui, xtz, ton, trx]
 

--- a/apps/ethereum/src/parser.ts
+++ b/apps/ethereum/src/parser.ts
@@ -99,7 +99,9 @@ export const parseEthTx = async (txRaw: string): Promise<AugmentedTransaction> =
     if (looksLikeObject(txRaw)) {
       const tx = JSON.parse(txRaw);
       // Never trust caller-supplied inputData — always derive from actual calldata.
-      delete (tx as AugmentedTransactionWithFunction).inputData;
+      // Cast through Partial: inputData is required on the augmented type, and TS
+      // rejects delete on a non-optional property (TS2790).
+      delete (tx as Partial<AugmentedTransactionWithFunction>).inputData;
       const inputData = await tryDecodeInputData(tx);
       if (inputData) {
         (tx as AugmentedTransactionWithFunction).inputData = inputData;

--- a/apps/ethereum/src/parser.ts
+++ b/apps/ethereum/src/parser.ts
@@ -99,9 +99,10 @@ export const parseEthTx = async (txRaw: string): Promise<AugmentedTransaction> =
     if (looksLikeObject(txRaw)) {
       const tx = JSON.parse(txRaw);
       // Never trust caller-supplied inputData — always derive from actual calldata.
-      // Cast through Partial: inputData is required on the augmented type, and TS
-      // rejects delete on a non-optional property (TS2790).
-      delete (tx as Partial<AugmentedTransactionWithFunction>).inputData;
+      // Asserted as an object that may carry the property rather than as the augmented
+      // type: this is unvalidated caller JSON, and delete needs the property optional
+      // (TS2790). Its value type is irrelevant to a delete.
+      delete (tx as { inputData?: unknown }).inputData;
       const inputData = await tryDecodeInputData(tx);
       if (inputData) {
         (tx as AugmentedTransactionWithFunction).inputData = inputData;


### PR DESCRIPTION
## What

Two commits, both aimed at the production deploy.

`apps/ethereum/src/parser.ts` deletes `inputData` through a cast to `AugmentedTransactionWithFunction`, where the property is required, so `tsc` rejects it (`TS2790`) and `@protocols/ethereum` has not compiled on `main`. The `delete` is deliberate — caller-supplied `inputData` must never be trusted — so only the cast changes, to `Partial<...>`. No behaviour change.

The deploy matrix also ran its 18 apps with `fail-fast` at its default, so the first job to fail cancelled the other seventeen. That is why a single broken app has read as a broken deploy since April: today `cronos` failed and 17 jobs were cancelled, in June `ethereum` failed and the other 17 were cancelled. Now `fail-fast: false`, so each app reports its own result.

**This PR is not sufficient to make the deploy pass.** `vercel pull` currently fails with `SAML re-authentication is required for kiln scope, but the token provided via --token does not have access` — the `VERCEL_TOKEN` secret needs replacing with one authorized against the SAML-enforced Vercel team. That is outside the repo, and is tracked in STA-280 alongside these two changes.

## Verification

`bun run build` and `bun run lint` pass across all 18 workspaces — the first time either has been clean on `main` since April, and previously `@protocols/ethereum` failed both. `bun test` passes (8 tests, 2 files). The ethereum app specifically: `bun --filter @protocols/ethereum build` and `lint` both exit 0, having exited 2 before.

The token half is unverified by definition: it cannot be exercised until the secret is rotated.

## Related
- Linear: [STA-280](https://linear.app/kiln/issue/STA-280/fix-unblock-minitel-production-deploys)
- Failing run: https://github.com/kilnfi/minitel/actions/runs/31790252373
